### PR TITLE
[#205,#220] Updates to playbooks (vSwitch)

### DIFF
--- a/comparison/ansible/k8s_worker_vswitch_mellanox.yml
+++ b/comparison/ansible/k8s_worker_vswitch_mellanox.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: localhost
   vars:
-    #    server_list: quadtestb-07,quadtestb-08
     facility: "{{ lookup('env','PACKET_FACILITY') }}"
-    deploy_env: "{{ lookup('env','K8S_DEPLOY_ENV') }}"
+    deploy_env: "{{ lookup('env','DEPLOY_ENV') }}"
+    server_list: "{{ lookup('env','SERVER_LIST') }}"
     project_name: "{{ lookup('env','PROJECT_NAME') }}"
     vlans:
       vlan1:

--- a/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
+++ b/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
@@ -5,8 +5,10 @@
 
 - hosts: localhost
   vars:
-    #    server_list: quadtestb-07,quadtestb-08   
-    deploy_env: k8sworker
+    facility: "{{ lookup('env','PACKET_FACILITY') }}"
+    deploy_env: "{{ lookup('env','DEPLOY_ENV') }}"
+    server_list: "{{ lookup('env','SERVER_LIST') }}"
+    project_name: "{{ lookup('env','PROJECT_NAME') }}"
     vlans:
       vlan1:
         interface: eth1
@@ -21,6 +23,8 @@
   vars:
     cnf: true
     vnf: false
+    # Run host vSwitch in container
+    vswitch_container: false
     baseline: false
     hugepages: 10240
     corelist_workers: 2,4,30,32
@@ -79,6 +83,14 @@
   - name: Install Vlan Package
     apt: 
       name: vlan
+  - name: Install pip
+    apt:
+      name: python-pip
+    when: vswitch_container
+  - name: Install docker-py
+    pip:
+      name: docker-py
+    when: vswitch_container
   - name: Get bond interface slaves
     setup:
       filter: "{{ ansible_bond0.slaves }}"
@@ -115,6 +127,8 @@
   roles:
     - mrlesmithjr.config-interfaces
     - grub_vswitch
-    - vpp_install #Vpp Install
+    - { role: "avinetworks.docker", when: vswitch_container }
+    - { role: "vpp_install", when: not vswitch_container }
+    - { role: "vpp_container_install", when: vswitch_container }
     - vpp_vswitch #Vpp vswitch configure,
     #Has unique config for quad intel cards

--- a/comparison/ansible/roles/rdma_mellanox_vpp/tasks/main.yml
+++ b/comparison/ansible/roles/rdma_mellanox_vpp/tasks/main.yml
@@ -73,11 +73,11 @@
   when: baseline
 
 - name: Write vpp startup config file
-  template: src=vEdge_startup.conf.j2 dest=/etc/vpp/old_startup.conf
+  template: src=vEdge_startup.conf.j2 dest=/etc/vpp/startup.conf
   when: not baseline
 
 - name: Update CNF VPP configuration
-  template: src=vEdge_cnf.conf.j2 dest=/etc/vpp/old_setup.gate
+  template: src=vEdge_cnf.conf.j2 dest=/etc/vpp/setup.gate
   when: cnf
 
 - name: Add 1 chain VPP template
@@ -93,7 +93,7 @@
   when: cnf
 
 - name: Update VNF VPP configuration
-  template:  src=vEdge_vnf.conf.j2 dest=/etc/vpp/old_setup.gate
+  template:  src=vEdge_vnf.conf.j2 dest=/etc/vpp/setup.gate
   when: vnf
 
 - name: Restart vpp

--- a/comparison/ansible/roles/rdma_mellanox_vpp/templates/vEdge_vnf.conf.j2
+++ b/comparison/ansible/roles/rdma_mellanox_vpp/templates/vEdge_vnf.conf.j2
@@ -4,19 +4,19 @@ create bridge-domain 2
 create vhost-user socket /var/run/vpp/sock1.sock server
 create vhost-user socket /var/run/vpp/sock2.sock server
 
-create sub TwentyFiveGigabitEthernet5e/0/1 1070
-create sub TwentyFiveGigabitEthernet5e/0/1 1064
+create sub TwentyFiveGigabitEthernet5e/0/1 {{ vlan_ids[0] }}
+create sub TwentyFiveGigabitEthernet5e/0/1 {{ vlan_ids[1] }}
 
-set int l2 bridge TwentyFiveGigabitEthernet5e/0/1.1070 1
+set int l2 bridge TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[0] }} 1
 set int l2 bridge VirtualEthernet0/0/0 1
-set int l2 bridge TwentyFiveGigabitEthernet5e/0/1.1064 2
+set int l2 bridge TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[1] }} 2
 set int l2 bridge VirtualEthernet0/0/1 2
 
 set int state TwentyFiveGigabitEthernet5e/0/1 up
-set int state TwentyFiveGigabitEthernet5e/0/1.1070 up
-set int state TwentyFiveGigabitEthernet5e/0/1.1064 up
+set int state TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[0] }} up
+set int state TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[1] }} up
 set int state VirtualEthernet0/0/0 up
 set int state VirtualEthernet0/0/1 up
 
-set interface l2 tag-rewrite TwentyFiveGigabitEthernet5e/0/1.1070 pop 1
-set interface l2 tag-rewrite TwentyFiveGigabitEthernet5e/0/1.1064 pop 1
+set interface l2 tag-rewrite TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[0] }} pop 1
+set interface l2 tag-rewrite TwentyFiveGigabitEthernet5e/0/1.{{ vlan_ids[1] }} pop 1

--- a/comparison/ansible/roles/vpp_container_install/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_container_install/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: find the controller host address
+  set_fact:
+    host_0_address: "{{hostvars[groups['all'][0]].ansible_bond0.ipv4.address}}"
+
+#- name: Enable use of vfio-pci driver
+#  replace:
+#    path: /lib/systemd/system/vpp.service
+#    regexp: 'uio_pci_generic'
+#    replace: 'vfio-pci'
+#    backup: no
+#  when: ansible_os_family == "Debian"
+
+- name: create VPP directory
+  file:
+    state: directory
+    dest: /etc/vpp
+    mode: 0755
+
+- name: add uplink vpp tap startup script
+  template:
+    src: uplink.conf
+    dest: /etc/vpp/uplink.conf
+  when: inventory_hostname == host_0_address
+
+- name: update vpp startup script for l3
+  template:
+    src: startupl3.conf
+    dest: /etc/vpp/startup.conf
+  when: inventory_hostname == host_0_address
+
+- name: update vpp startup script compute
+  template:
+    src: startup.conf
+    dest: /etc/vpp/startup.conf
+  when: not inventory_hostname == host_0_address
+
+- name: make sure vfio-pci loads on startup
+  template:
+    src: vfio-pci.conf
+    dest: /etc/modules-load.d/vfio-pci.conf
+
+- name: Docker start vppcontainer (Intel)
+  docker_container:
+    name: vppcontainer
+    image: soelvkaer/vppcontainer:latest
+    state: started
+    network_mode: host
+    privileged: true
+    restart_policy: always
+    devices:
+      - "/dev/hugepages/:/dev/hugepages/:rwm"
+    volumes:
+      - /etc/vpp/:/etc/vpp/
+      - /dev:/dev

--- a/comparison/ansible/roles/vpp_container_install/templates/startup.conf
+++ b/comparison/ansible/roles/vpp_container_install/templates/startup.conf
@@ -1,0 +1,34 @@
+unix {
+  nodaemon
+  log /var/log/vpp/vpp.log
+  full-coredump
+  cli-listen /run/vpp/cli.sock
+  gid vpp
+}
+
+api-trace {
+  on
+}
+
+api-segment {
+  gid vpp
+}
+
+cpu {
+  main-core 0
+  corelist-workers 2,4,30,32
+  heapsize {
+   2G
+  }
+}
+
+dpdk {
+  dev default {
+    num-rx-queues 4
+  }
+  no-multi-seg
+  num-mbufs 65536
+  no-tx-checksum-offload
+  huge-dir /dev/hugepages
+  socket-mem 2048,2048
+}

--- a/comparison/ansible/roles/vpp_container_install/templates/startupl3.conf
+++ b/comparison/ansible/roles/vpp_container_install/templates/startupl3.conf
@@ -1,0 +1,28 @@
+unix {
+  nodaemon
+  log /var/log/vpp/vpp.log
+  full-coredump
+  cli-listen /run/vpp/cli.sock
+  startup-config /etc/vpp/uplink.conf
+  gid vpp
+}
+
+api-trace {
+  on
+}
+
+api-segment {
+  gid vpp
+}
+
+cpu {
+  main-core 1
+  heapsize {
+   2G
+  }
+}
+
+dpdk {
+  huge-dir /dev/hugepages
+  socket-mem 2048,2048
+}

--- a/comparison/ansible/roles/vpp_container_install/templates/uplink.conf
+++ b/comparison/ansible/roles/vpp_container_install/templates/uplink.conf
@@ -1,0 +1,1 @@
+tap connect uplink

--- a/comparison/ansible/roles/vpp_container_install/templates/vfio-pci.conf
+++ b/comparison/ansible/roles/vpp_container_install/templates/vfio-pci.conf
@@ -1,0 +1,1 @@
+vfio-pci

--- a/comparison/ansible/roles/vpp_vswitch/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_vswitch/tasks/main.yml
@@ -37,6 +37,11 @@
   service: 
     name: vpp
     state: restarted
+  when: not vswitch_container
+
+- name: Restart vpp (container)
+  command: docker restart vppcontainer
+  when: vswitch_container
 
 - name: Write hugepages sys.conf
   template: src=80-vpp.conf.j2 dest=/etc/sysctl.d/80-vpp.conf


### PR DESCRIPTION
A few fixes to RDMA Mellanox vSwitch (not container) and added support for Intel vSwitch in container

@robertstarmer @linkous8 I don't think this will have any impact with the Openstack master node deployment, since I created a different role for the containerized vswitch deployment (vpp_container_install, copy of vpp_install) that is only called from k8s_worker_vswitch_quad_intel.yml. I will however still give you a chance to check it over before changes are merged to master.