### PR TITLE
[#286] Add SRIOV Network Device Plugin (Infra + use-case)

### DIFF
--- a/examples/use_case/sriov-device-on-k8s-on-packet/README.md
+++ b/examples/use_case/sriov-device-on-k8s-on-packet/README.md
@@ -1,0 +1,57 @@
+## Install POD using the SRIOV Network Device Plugin on Kubernetes
+
+This example is used to install a POD using the [SRIOV Network Device Plugin](https://github.com/intel/sriov-network-device-plugin).
+
+The POD is assigned a sigle port using vfio-pci, which is then attached to an instance of VPP running in the container.
+
+### Limitations
+
+The SRIOV Network Device Plugin is intended for providing a limited set of resources to a running container. For this example, the POD is running in privileged mode, which makes all of the available ports using the vfio-pci driver visible inside the container. The POD created through this example will read the list of assigned ports from the environment and configure VPP to only use the allocated resources.
+
+The reason for privileged mode is errors with VPP due to hugepages and access to the vfio-pci kernel module. We are looking into a solution that allows running it unprivilged, but by limiting the configuration to the assigned resources from the SRIOV Device Plugin, the resulting behavior will emulate that of the intended plugin behavior.
+
+### Prerequisites
+A Kubernetes deployment with the SRIOV Network Device Plugin installed must be available.
+
+You should have a `kubeconfig` file ready on the machine.
+
+`kubectl` must be installed. The steps included here are taken fron [kubernetes.io](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-linux):
+```
+$ curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+$ chmod +x kubectl
+$ mv kubectl /usr/local/bin/kubectl
+```
+
+### Installing the example POD
+Install the POD by running the below commands from this directory:
+```
+## set environment variable for KUBECONFIG (replace path to match your location)
+$ export KUBECONFIG=<path>/<to>/kubeconfig
+$ kubectl apply -f sriov-simple-vpp-pod.yaml
+```
+
+### Verifying POD deployment
+There are a few steps that can be used to verify that the POD deployed correctly:
+```
+## Start by checking that the POD is running (you might need to way a few seconds after deploying)
+$ kubectl get pods
+
+## Once running, enter the container
+$ kubectl exec -it sriov-simple-vpp-pod /bin/bash
+
+## Check for an allocated PCI device (NIC port)
+$$ env | grep PCIDEVICE
+PCIDEVICE_INTEL_COM_VFIO_PORTS=0000:XX:XX.X
+
+## Check that the device has been added to the VPP startup configuration
+$$ cat /etc/vpp/startup.conf | grep dev
+dev 0000:XX:XX.X
+
+## Finally check that the interface is visible in VPP
+$$ vppctl show int
+              Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count
+TenGigabitEthernetXX/X/X          1     down         9000/0/0/0
+local0                            0     down          0/0/0/0
+```
+
+The interface in VPP will be in state down, as no `setup.gate` file is provided with the example. You can add a configuration directly through the CLI (`vppcl`), or you can add one as part of the configMap in the example file `sriov-simple-vpp-pod.yaml`, which should be mapped to `/etc/vpp/setup.gate` inside the container.

--- a/examples/use_case/sriov-device-on-k8s-on-packet/README.md
+++ b/examples/use_case/sriov-device-on-k8s-on-packet/README.md
@@ -2,13 +2,13 @@
 
 This example is used to install a POD using the [SRIOV Network Device Plugin](https://github.com/intel/sriov-network-device-plugin).
 
-The POD is assigned a sigle port using vfio-pci, which is then attached to an instance of VPP running in the container.
+The POD is assigned a single port using vfio-pci, which is then attached to an instance of VPP running in the container.
 
 ### Limitations
 
 The SRIOV Network Device Plugin is intended for providing a limited set of resources to a running container. For this example, the POD is running in privileged mode, which makes all of the available ports using the vfio-pci driver visible inside the container. The POD created through this example will read the list of assigned ports from the environment and configure VPP to only use the allocated resources.
 
-The reason for privileged mode is errors with VPP due to hugepages and access to the vfio-pci kernel module. We are looking into a solution that allows running it unprivilged, but by limiting the configuration to the assigned resources from the SRIOV Device Plugin, the resulting behavior will emulate that of the intended plugin behavior.
+The reason for privileged mode is errors with VPP due to hugepages and access to the vfio-pci kernel module. We are looking into a solution that allows running it unprivileged, but by limiting the configuration to the assigned resources from the SRIOV Device Plugin, the resulting behavior will emulate that of the intended plugin behavior.
 
 ### Prerequisites
 A Kubernetes deployment with the SRIOV Network Device Plugin installed must be available.

--- a/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
+++ b/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
@@ -14,9 +14,7 @@ spec:
     imagePullPolicy: IfNotPresent
     securityContext:
       privileged: true
-    #command: [ "/bin/bash", "-c", "--" ]
     command: [ "/bin/bash", "/opt/vpp/run_vpp.sh" ]
-    #args: [ "while true; do sleep 300000; done;" ]
     resources:
       requests:
         memory: 200Mi
@@ -93,7 +91,7 @@ data:
 
     cp /opt/vpp/startup.template /etc/vpp/startup.conf
 
-    devstring="      "
+    devstring="  "
 
     # Avoiding modifications to IFS
     for i in $(echo $pcidevs | sed "s/,/ /g"); do

--- a/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
+++ b/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
@@ -17,6 +17,7 @@ spec:
     command: [ "/bin/bash", "/opt/vpp/run_vpp.sh" ]
     resources:
       requests:
+        hugepages-2Mi: 100Mi
         memory: 200Mi
         intel.com/vfio_ports: '1'
       limits:

--- a/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
+++ b/examples/use_case/sriov-device-on-k8s-on-packet/sriov-simple-vpp-pod.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sriov-simple-vpp-pod
+  labels:
+    env: test
+spec:
+  tolerations:
+  - operator: "Exists"
+  hostNetwork: true
+  containers:
+  - name: sriovdpdk
+    image: soelvkaer/vppcontainer:latest
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+    #command: [ "/bin/bash", "-c", "--" ]
+    command: [ "/bin/bash", "/opt/vpp/run_vpp.sh" ]
+    #args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        memory: 200Mi
+        intel.com/vfio_ports: '1'
+      limits:
+        hugepages-2Mi: 100Mi
+        memory: 200Mi
+        intel.com/vfio_ports: '1'
+    volumeMounts:
+    - name: hugepage
+      mountPath: /dev/hugepages/
+    - name: vppconf
+      mountPath: /opt/vpp/
+  volumes:
+    - name: hugepage
+      emptyDir:
+        medium: HugePages
+    - name: vppconf
+      configMap:
+        name: vppconfig
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vppconfig
+data:
+  startup.template: |
+    unix {
+      nodaemon
+      log /var/log/vpp/vpp.log
+      full-coredump
+      cli-listen /run/vpp/cli.sock
+      gid vpp
+      startup-config /etc/vpp/setup.gate
+    }
+
+    api-trace {
+      on
+    }
+
+    api-segment {
+      gid vpp
+    }
+
+    socksvr {
+      default
+    }
+
+    cpu {
+
+    }
+
+    dpdk {
+      PCIID
+      no-multi-seg
+      no-tx-checksum-offload
+    }
+
+    plugins {
+      plugin default { disable }
+      plugin dpdk_plugin.so { enable }
+      plugin memif_plugin.so { enable }
+    }
+  run_vpp.sh: |
+    #! /bin/bash
+
+    pcidevs=$(env | grep PCIDEVICE | awk -F'=' '{print $2}')
+    echo $pcidevs
+    
+    if [ -z "$pcidevs" ]; then
+        echo "ERROR: No PCI devices listed in env"
+        exit 1
+    fi
+
+    cp /opt/vpp/startup.template /etc/vpp/startup.conf
+
+    devstring="      "
+
+    # Avoiding modifications to IFS
+    for i in $(echo $pcidevs | sed "s/,/ /g"); do
+      devstring="${devstring}dev $i "
+    done
+
+    sed -i "s/.*PCIID.*/${devstring}/g" /etc/vpp/startup.conf
+
+    vpp -c /etc/vpp/startup.conf 2>&1 | tee /etc/vpp/output.log

--- a/examples/workload-infra/sriov-device-plugin-k8s/README.md
+++ b/examples/workload-infra/sriov-device-plugin-k8s/README.md
@@ -9,6 +9,13 @@ A Kubernetes deployment must be avaialble prior to installing the plugin.
 
 You should have a `kubeconfig` file ready on the machine used for installing the plugin.
 
+`kubectl` must be installed. The steps included here are taken fron [kubernetes.io](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-linux):
+```
+$ curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+$ chmod +x kubectl
+$ mv kubectl /usr/local/bin/kubectl
+```
+
 Before installing, connect (SSH) to the worker node of the Kubernetes cluster, and stop any instance of VPP running on the node:
 ```
 ## If running as a service

--- a/examples/workload-infra/sriov-device-plugin-k8s/README.md
+++ b/examples/workload-infra/sriov-device-plugin-k8s/README.md
@@ -1,0 +1,45 @@
+# K8s cluster with SRIOV Network Device Plugin
+
+## Install SRIOV Network Device Plugin on an existing Kubernetes deployment
+
+This example is used to install the [SRIOV Network Device Plugin](https://github.com/intel/sriov-network-device-plugin) with a simple configuration. The provided configuration uses a pre-built image (soelvkaer/sriov-device-plugin:latest) similar to what can be created by running `make && make image` from the [source repository](https://github.com/intel/sriov-network-device-plugin). The configuration provided here is also based on examples already provided with the code.
+
+### Prerequisites
+A Kubernetes deployment must be avaialble prior to installing the plugin.
+
+You should have a `kubeconfig` file ready on the machine used for installing the plugin.
+
+Before installing, connect (SSH) to the worker node of the Kubernetes cluster, and stop any instance of VPP running on the node:
+```
+## If running as a service
+$ service vpp stop
+
+## If running as a container
+$ docker stop vppcontainer
+```
+
+### Installing SRIOV Network Device Plugin
+Install the plugin with a simple configuration by running the following command from this directory:
+```
+## set environment variable for KUBECONFIG (replace path to match your location)
+$ export KUBECONFIG=<path>/<to>/kubeconfig
+$ kubectl apply -f configMap.yaml -f sriovdp-daemonset.yaml
+```
+
+After installing the plugin, you can verify that there are ports/interfaces available by running the following commands:
+```
+$ kubectl get nodes
+## Copy the name of the node
+
+$ kubectl get node <name of node> -o json | jq '.status.allocatable'
+## Output similar to the below should be seen
+{
+  "cpu": "55",
+  "ephemeral-storage": "210725550141",
+  "hugepages-1Gi": "0",
+  "hugepages-2Mi": "20Gi",
+  "intel.com/vfio_ports": "2",  <--- Node has two ports
+  "memory": "373838964Ki",
+  "pods": "110"
+}
+```

--- a/examples/workload-infra/sriov-device-plugin-k8s/configMap.yaml
+++ b/examples/workload-infra/sriov-device-plugin-k8s/configMap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnf-testbed-sriov-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [{
+                "resourceName": "vfio_ports",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["1572"],
+                    "drivers": ["vfio-pci"]
+                }
+            }
+        ]
+    }

--- a/examples/workload-infra/sriov-device-plugin-k8s/sriovdp-daemonset.yaml
+++ b/examples/workload-infra/sriov-device-plugin-k8s/sriovdp-daemonset.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: soelvkaer/sriov-device-plugin:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: config-volume
+          configMap:
+            name: cnf-testbed-sriov-config
+            items:
+            - key: config.json
+              path: config.json


### PR DESCRIPTION
**Adds the following:**
`workload_infra` deployment, that will manage two ports on an `n2.xlarge` machine provisioned with Kubernetes and a host vSwitch (see README for steps to stop this prior to running the example). The example has not been tested on m2.xlarge (Mellanox NIC).

`use_case` example that created a POD with 1 assigned interface. The interface is added to VPP, but no additional configuration is provided.
The POD is running in privileged mode due to limitations with VPP and the DPDK plugin used to manage the attached interface using the vfio-pci driver. More info on this can be seen in the provided README file.


https://github.com/cncf/cnf-testbed/issues/289