### PR TITLE
Fix issues with VPP seen in CNF Testbed

### DIFF
--- a/comparison/ansible/k8s_worker_vswitch_mellanox.yml
+++ b/comparison/ansible/k8s_worker_vswitch_mellanox.yml
@@ -34,7 +34,7 @@
     enable_configured_interfaces_after_defining: true
     dns_nameservers:
       - "{{ ansible_dns.nameservers[0] }}"
-      - "{{ ansible_dns.nameservers[0] }}"
+      - "{{ ansible_dns.nameservers[1] }}"
     network_bonds:
       - name: 'bond0'
         configure: true

--- a/comparison/ansible/k8s_worker_vswitch_mellanox.yml
+++ b/comparison/ansible/k8s_worker_vswitch_mellanox.yml
@@ -22,7 +22,7 @@
     nic_type: "mellanox"
     baseline: false # Currently no difference in VPP config
     hugepages: 18432
-    corelist_workers: 2,4,6,30,32,34
+    corelist_workers: 3
     rx_queues: 6
     mellanox_data_port: "{{ ansible_enp94s0f1.pciid }}"
     vlan_ids:

--- a/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
+++ b/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
@@ -29,7 +29,7 @@
     multus_cni: false
     baseline: false
     hugepages: 10240
-    corelist_workers: 2,4,6,30,32,34
+    corelist_workers: 3
     rx_queues: 3
     config_network_bonds: true
     config_network_bridges: false

--- a/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
+++ b/comparison/ansible/k8s_worker_vswitch_quad_intel.yml
@@ -41,7 +41,7 @@
     nic_port3: "{{ ansible_eno3.pciid }}"
     dns_nameservers:
       - "{{ ansible_dns.nameservers[0] }}"
-      - "{{ ansible_dns.nameservers[0] }}"
+      - "{{ ansible_dns.nameservers[1] }}"
     network_bonds:
       - name: 'bond0'
         configure: true

--- a/comparison/ansible/roles/rdma_mellanox_vpp/tasks/main.yml
+++ b/comparison/ansible/roles/rdma_mellanox_vpp/tasks/main.yml
@@ -25,7 +25,7 @@
   git:
     repo: 'https://github.com/FDio/vpp.git'
     dest: /srv/vpp
-    version: v19.08.1
+    version: v20.01
     update: no
   when: not vswitch_container
 

--- a/comparison/ansible/roles/vpp_config/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_config/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Run get_thread_list.sh
+  command: /opt/get_thread_list.sh 0 {{ corelist_workers }}
+  register: worker_threads
+  failed_when: worker_threads.rc > 0
+
 - name: Create vpp sockets directory
   file: path=/etc/vpp/sockets state=directory
 

--- a/comparison/ansible/roles/vpp_config/templates/3c2n-csc.j2
+++ b/comparison/ansible/roles/vpp_config/templates/3c2n-csc.j2
@@ -2,29 +2,29 @@ create bridge-domain 1
 create bridge-domain 2
 create bridge-domain 3
 
-bin memif_socket_filename_add_del add id 1 filename /etc/vpp/sockets/memif1.sock
+create memif socket id 1 filename /etc/vpp/sockets/memif1.sock
 create interface memif id 1 socket-id 1 master
-bin memif_socket_filename_add_del add id 2 filename /etc/vpp/sockets/memif2.sock
+create memif socket id 2 filename /etc/vpp/sockets/memif2.sock
 create interface memif id 2 socket-id 2 master
-bin memif_socket_filename_add_del add id 3 filename /etc/vpp/sockets/memif3.sock
+create memif socket id 3 filename /etc/vpp/sockets/memif3.sock
 create interface memif id 3 socket-id 3 master
-bin memif_socket_filename_add_del add id 4 filename /etc/vpp/sockets/memif4.sock
+create memif socket id 4 filename /etc/vpp/sockets/memif4.sock
 create interface memif id 4 socket-id 4 master
-bin memif_socket_filename_add_del add id 5 filename /etc/vpp/sockets/memif5.sock
+create memif socket id 5 filename /etc/vpp/sockets/memif5.sock
 create interface memif id 5 socket-id 5 master
-bin memif_socket_filename_add_del add id 6 filename /etc/vpp/sockets/memif6.sock
+create memif socket id 6 filename /etc/vpp/sockets/memif6.sock
 create interface memif id 6 socket-id 6 master
-bin memif_socket_filename_add_del add id 7 filename /etc/vpp/sockets/memif7.sock
+create memif socket id 7 filename /etc/vpp/sockets/memif7.sock
 create interface memif id 7 socket-id 7 master
-bin memif_socket_filename_add_del add id 8 filename /etc/vpp/sockets/memif8.sock
+create memif socket id 8 filename /etc/vpp/sockets/memif8.sock
 create interface memif id 8 socket-id 8 master
-bin memif_socket_filename_add_del add id 9 filename /etc/vpp/sockets/memif9.sock
+create memif socket id 9 filename /etc/vpp/sockets/memif9.sock
 create interface memif id 9 socket-id 9 master
-bin memif_socket_filename_add_del add id 10 filename /etc/vpp/sockets/memif10.sock
+create memif socket id 10 filename /etc/vpp/sockets/memif10.sock
 create interface memif id 10 socket-id 10 master
-bin memif_socket_filename_add_del add id 11 filename /etc/vpp/sockets/memif11.sock
+create memif socket id 11 filename /etc/vpp/sockets/memif11.sock
 create interface memif id 11 socket-id 11 master
-bin memif_socket_filename_add_del add id 12 filename /etc/vpp/sockets/memif12.sock
+create memif socket id 12 filename /etc/vpp/sockets/memif12.sock
 create interface memif id 12 socket-id 12 master
 
 set int l2 bridge memif1/1 1

--- a/comparison/ansible/roles/vpp_config/templates/3c2n-csp.j2
+++ b/comparison/ansible/roles/vpp_config/templates/3c2n-csp.j2
@@ -1,17 +1,17 @@
 create bridge-domain 1
 create bridge-domain 2
 
-bin memif_socket_filename_add_del add id 1 filename /etc/vpp/sockets/memif1.sock
+create memif socket id 1 filename /etc/vpp/sockets/memif1.sock
 create interface memif id 1 socket-id 1 master
-bin memif_socket_filename_add_del add id 2 filename /etc/vpp/sockets/memif2.sock
+create memif socket id 2 filename /etc/vpp/sockets/memif2.sock
 create interface memif id 2 socket-id 2 master
-bin memif_socket_filename_add_del add id 3 filename /etc/vpp/sockets/memif3.sock
+create memif socket id 3 filename /etc/vpp/sockets/memif3.sock
 create interface memif id 3 socket-id 3 master
-bin memif_socket_filename_add_del add id 4 filename /etc/vpp/sockets/memif4.sock
+create memif socket id 4 filename /etc/vpp/sockets/memif4.sock
 create interface memif id 4 socket-id 4 master
-bin memif_socket_filename_add_del add id 5 filename /etc/vpp/sockets/memif5.sock
+create memif socket id 5 filename /etc/vpp/sockets/memif5.sock
 create interface memif id 5 socket-id 5 master
-bin memif_socket_filename_add_del add id 6 filename /etc/vpp/sockets/memif6.sock
+create memif socket id 6 filename /etc/vpp/sockets/memif6.sock
 create interface memif id 6 socket-id 6 master
 
 set int l2 bridge memif1/1 1

--- a/comparison/ansible/roles/vpp_config/templates/startup.j2
+++ b/comparison/ansible/roles/vpp_config/templates/startup.j2
@@ -21,7 +21,7 @@ socksvr {
 
 cpu {
   main-core 0
-  corelist-workers {{ corelist_workers }}
+  corelist-workers {{ worker_threads.stdout }}
 }
 
 buffers {

--- a/comparison/ansible/roles/vpp_install/defaults/main.yml
+++ b/comparison/ansible/roles/vpp_install/defaults/main.yml
@@ -1,2 +1,2 @@
 vpp_branch: "release" # branch on packagecloud
-vpp_ver: "19.08.1" # release version
+vpp_ver: "20.01" # release version

--- a/examples/network_functions/rdma_vppcontainer/Dockerfile
+++ b/examples/network_functions/rdma_vppcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update && apt install -y \
     vim \
     systemd
 
-RUN git clone https://github.com/FDio/vpp.git --branch v19.08.1 --single-branch /srv/vpp
+RUN git clone https://github.com/FDio/vpp.git --branch v20.01 --single-branch /srv/vpp
 
 RUN cd /srv/vpp \
     && yes Y | make install-dep \

--- a/examples/network_functions/vppcontainer/Dockerfile
+++ b/examples/network_functions/vppcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV VPP_VER "19.08.1"
+ENV VPP_VER "20.01"
 
 RUN apt-get update && apt-get install -y \
     vlan \

--- a/examples/use_case/3c2n-csc/csc/templates/configmap.yaml
+++ b/examples/use_case/3c2n-csc/csc/templates/configmap.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
 {{ range $k, $v := .Values.cnf }}
   setup_{{$k}}.gate: |-
-    bin memif_socket_filename_add_del add id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
-    bin memif_socket_filename_add_del add id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
+    create memif socket id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
+    create memif socket id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
     create interface memif id {{ index .memid 0 }} socket-id 1 hw-addr {{ index .mac 0 }} {{ index .owner 0 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     create interface memif id {{ index .memid 1 }} socket-id 2 hw-addr {{ index .mac 1 }} {{ index .owner 1 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     set int ip addr memif1/{{ index .memid 0 }} {{ index .subnet 0 }}

--- a/examples/use_case/3c2n-csp/csp/templates/configmap.yaml
+++ b/examples/use_case/3c2n-csp/csp/templates/configmap.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
 {{ range $k, $v := .Values.cnf }}
   setup_{{$k}}.gate: |-
-    bin memif_socket_filename_add_del add id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
-    bin memif_socket_filename_add_del add id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
+    create memif socket id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
+    create memif socket id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
     create interface memif id {{ index .memid 0 }} socket-id 1 hw-addr {{ index .mac 0 }} {{ index .owner 0 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     create interface memif id {{ index .memid 1 }} socket-id 2 hw-addr {{ index .mac 1 }} {{ index .owner 1 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     set int ip addr memif1/{{ index .memid 0 }} {{ index .subnet 0 }}

--- a/examples/use_case/ipsec/ipsec/templates/configmap.yaml
+++ b/examples/use_case/ipsec/ipsec/templates/configmap.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
 {{ range $k, $v := .Values.cnf }}
   setup_{{$k}}.gate: |-
-    bin memif_socket_filename_add_del add id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
-    bin memif_socket_filename_add_del add id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
+    create memif socket id 1 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 0 }}.sock
+    create memif socket id 2 filename {{ $.Values.volumeMounts.vpp_sockets.mountPath }}/{{ index .sock 1 }}.sock
     create interface memif id {{ index .memid 0 }} socket-id 1 hw-addr {{ index .mac 0 }} {{ index .owner 0 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     create interface memif id {{ index .memid 1 }} socket-id 2 hw-addr {{ index .mac 1 }} {{ index .owner 1 }} rx-queues {{ .queues }} tx-queues {{ .queues }}
     set int ip addr memif1/{{ index .memid 0 }} {{ index .subnet 0 }}


### PR DESCRIPTION
## PR does the following
- Changes the configuration of VPP `corelist_workers` from a list of threads to an integer value specifying the number of cores (not threads) to use.
- Updates VPP from v19.08.1 to v20.01 for host and containerized deployments
- Updates VPP configuration files to use correct CLI command for createing memif sockets (`create memif socket`)
- Adds use of `get_thread_list.sh` script to Ansible role creating VPP configuration files

## Not handled in PR
- VPP based use-cases (3c2n-csc/csp, IPsec) have `worker_cores` defined through Helm values file. These are specific to the CPU, enumeration method and host vSwitch core allocation.

## Dependencies
cncf/cnf-testbed#337 - Script for CPU isolation and VPP core allocation is needed

## Issues
cncf/cnf-testbed#338

## How Has This Been Tested?
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.