### PR TITLE
Reduce the size of Network Functions Docker images

### DIFF
--- a/examples/network_functions/go-gtp/Dockerfile
+++ b/examples/network_functions/go-gtp/Dockerfile
@@ -1,12 +1,18 @@
-FROM golang:alpine
+FROM golang:1.14-alpine3.11 as builder
+
 RUN apk --no-cache add git
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/enb
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/mme
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/pgw
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/sgw
-ADD ["enb/enb_default.yml","/root/enb.yml"]
-ADD ["mme/mme_default.yml","/root/mme.yml"]
-ADD ["pgw/pgw_default.yml","/root/pgw.yml"]
-ADD ["sgw/sgw_default.yml","/root/sgw.yml"]
-RUN apk del git
-WORKDIR /root/
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/enb
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/mme
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/pgw
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/sgw
+
+FROM alpine:3.11
+
+COPY --from=builder /go/bin/enb /usr/local/bin/
+COPY --from=builder /go/bin/mme /usr/local/bin/
+COPY --from=builder /go/bin/pgw /usr/local/bin/
+COPY --from=builder /go/bin/sgw /usr/local/bin/
+COPY ./enb/enb_default.yml /etc/enb.yml
+COPY ./mme/mme_default.yml /etc/mme.yml
+COPY ./pgw/pgw_default.yml /etc/pgw.yml
+COPY ./sgw/sgw_default.yml /etc/sgw.yml

--- a/examples/network_functions/go-gtp/enb/Dockerfile
+++ b/examples/network_functions/go-gtp/enb/Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:alpine
-RUN apk --no-cache add git bash gettext
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/enb
-ADD ["./enb_default.yml","/root/enb.yml"]
-RUN apk del git
-WORKDIR /root/
+FROM golang:1.14-alpine3.11 as builder
+
+RUN apk --no-cache add git
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/enb
+
+FROM alpine:3.11
+
+COPY --from=builder /go/bin/enb /usr/local/bin/
+COPY ./enb_default.yml /etc/enb.yml
+
+ENTRYPOINT ["/usr/local/bin/enb", "-config", "/etc/enb.yml"]

--- a/examples/network_functions/go-gtp/mme/Dockerfile
+++ b/examples/network_functions/go-gtp/mme/Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:alpine
-RUN apk --no-cache add git bash gettext
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/mme
-ADD ["./mme_default.yml","/root/mme.yml"]
-RUN apk del git
-WORKDIR /root/
+FROM golang:1.14-alpine3.11 as builder
+
+RUN apk --no-cache add git
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/mme
+
+FROM alpine:3.11
+
+COPY --from=builder /go/bin/mme /usr/local/bin/
+COPY ./mme_default.yml /etc/mme.yml
+
+ENTRYPOINT ["/usr/local/bin/mme", "-config", "/etc/mme.yml"]

--- a/examples/network_functions/go-gtp/pgw/Dockerfile
+++ b/examples/network_functions/go-gtp/pgw/Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:alpine
-RUN apk --no-cache add git bash gettext
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/pgw
-ADD ["./pgw_default.yml","/root/pgw.yml"]
-RUN apk del git
-WORKDIR /root/
+FROM golang:1.14-alpine3.11 as builder
+
+RUN apk --no-cache add git
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/pgw
+
+FROM alpine:3.11
+
+COPY --from=builder /go/bin/pgw /usr/local/bin/
+COPY ./pgw_default.yml /etc/pgw.yml
+
+ENTRYPOINT ["/usr/local/bin/pgw", "-config", "/etc/pgw.yml"]

--- a/examples/network_functions/go-gtp/sgw/Dockerfile
+++ b/examples/network_functions/go-gtp/sgw/Dockerfile
@@ -1,6 +1,11 @@
-FROM golang:alpine
-RUN apk --no-cache add git bash gettext
-RUN go get github.com/wmnsk/go-gtp/examples/gw-tester/sgw
-ADD ["./sgw_default.yml","/root/sgw.yml"]
-RUN apk del git
-WORKDIR /root/
+FROM golang:1.14-alpine3.11 as builder
+
+RUN apk --no-cache add git
+RUN go get -v github.com/wmnsk/go-gtp/examples/gw-tester/sgw
+
+FROM alpine:3.11
+
+COPY --from=builder /go/bin/sgw /usr/local/bin/
+COPY ./sgw_default.yml /etc/sgw.yml
+
+ENTRYPOINT ["/usr/local/bin/sgw", "-config", "/etc/sgw.yml"]


### PR DESCRIPTION
The current Dockerfile implementation of the Network Functions has the following sizes

| Image name | Size      |
|:-------------|:-------:|
| gogtp:sgw    | 482MB |
| gogtp:mme       | 649MB |
| gogtp:pgw       | 481MB |
| gogtp:enb       | 655MB |
| gogtp:latest    | 696MB |

Implementing some of the [official best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/), the following results can be achieved.

| Image name | Size      |
|:-------------|:-------:|
| gogtp:sgw     | 20.6MB |
| gogtp:mme     | 21.5MB |
| gogtp:pgw     | 20.5MB |
| gogtp:enb     | 22.2MB |
| gogtp:latest  | 68MB |

So these changes reduce the space required by the Docker registry.