### PR TITLE
VPP Docker image improvements

### DIFF
--- a/examples/network_functions/vppcontainer/Dockerfile
+++ b/examples/network_functions/vppcontainer/Dockerfile
@@ -2,23 +2,18 @@ FROM ubuntu:18.04
 
 ENV VPP_VER "20.01"
 
-RUN apt-get update && apt-get install -y \
-    vlan \
-    vim \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg \
+    apt-transport-https \
     curl \
-    systemd
+    ca-certificates
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
-
-RUN apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     dpdk \
     vpp=${VPP_VER}-release \
     vpp-plugin-core=${VPP_VER}-release \
     vpp-plugin-dpdk=${VPP_VER}-release \
-    vpp-dev=${VPP_VER}-release \
-    vpp-dbg=${VPP_VER}-release \
     libvppinfra=${VPP_VER}-release
 
-COPY shared/run_vpp.sh /tmp/
-
-ENTRYPOINT ["bash", "/tmp/run_vpp.sh"]
+CMD ["/usr/bin/vpp", "-c", "/etc/vpp/startup.conf"]

--- a/examples/network_functions/vppcontainer/README.md
+++ b/examples/network_functions/vppcontainer/README.md
@@ -3,7 +3,7 @@ This base-image provides a containerized, configurable deployment of VPP v19.04.
 * CNF use-case deployments (3c2n-csc, 3c2n-csp, ipsec)
 * Host vSwitch, when using n2.xlarge servers provided by Packet (Intel X710 NIC)
 
-Configuration is currently done though a volume mount on the host, where relevant VPP configuration files are located. The local directory should contain a VPP configuration file named `startup.conf` (and any additional setup files used by this), and the directory should map to /etc/vpp/ in the container (i.e. `/etc/vpp/startup.conf`). The mapped host directory is also used for storing the VPP logs in `output.log`.
+Configuration is currently done though a volume mount on the host, where relevant VPP configuration files are located. The local directory should contain a VPP configuration file named `startup.conf` (and any additional setup files used by this), and the directory should map to /etc/vpp/ in the container (i.e. `/etc/vpp/startup.conf`). The VPP logs are unbuffered to standard output.
 
 The image is based on Ubuntu 18.04 LTS.
 
@@ -40,7 +40,7 @@ With the prerequisites installed, the vppcontainer image can be built as follows
 ./builder.sh
 ```
 
-Once completed the image can be seen with `docker image ls`. Currently, CNF Testbed does not utilize any local storage for images, but an easy solution is to upload the image to [Docker Hub](https://hub.docker.com/).
+Once completed the image can be seen with `docker images`. Currently, CNF Testbed does not utilize any local storage for images, but an easy solution is to upload the image to [Docker Hub](https://hub.docker.com/).
 
 To use Docker Hub for storing images, start by creating an account if you don't have one already. Then tag the image as follows:
 ```

--- a/examples/network_functions/vppcontainer/shared/run_vpp.sh
+++ b/examples/network_functions/vppcontainer/shared/run_vpp.sh
@@ -1,2 +1,0 @@
-#! /bin/bash
-vpp -c /etc/vpp/startup.conf 2>&1 | tee /etc/vpp/output.log


### PR DESCRIPTION
This change reduces the size of the VPP container image from 452MB to 212MB by installing only the minimal packages required for its execution. Furthermore,  it removes the instruction to store logs entries in files to follow the [Twelve-Factor App](https://12factor.net/logs) principles.