### PR TITLE
Helm chart for basic VPP CNF [#346]

### DIFF
--- a/examples/network_functions/vpp-ip-forwarder/README.md
+++ b/examples/network_functions/vpp-ip-forwarder/README.md
@@ -1,0 +1,15 @@
+## Helm chart for installing example VPP CNFs
+
+This Helm chart can be used to install any number of pods running containerized VPP. In addition to the pods, the chart will also deploy a host bridge through Multus, with each pod attaching to the bridge with an interface that is available in VPP.
+
+### Installing the example VPP CNFs
+By default a single pod will be deployed. If more are needed, update `vpp/values.yaml` with additional entries under `cnf` (an example for a second CNF is included, but commented).
+
+By default, VPP will enable the bridge interface added to the pod. If additional configuration is needed, update `vpp/templates/configmap.yaml` with the necessary CLI commands.
+
+Once everything is configured, install the VPP CNFs using the below commands
+```
+## set environment variable for KUBECONFIG (replace path to match your location)
+$ export KUBECONFIG=<path>/<to>/kubeconfig
+$ helm install ./vpp/
+```

--- a/examples/network_functions/vpp-ip-forwarder/vpp/.helmignore
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/examples/network_functions/vpp-ip-forwarder/vpp/Chart.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A basic deployment of VPP attached to a host bridge
+name: vpp
+version: 0.1.0

--- a/examples/network_functions/vpp-ip-forwarder/vpp/templates/bridge.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/templates/bridge.yaml
@@ -1,0 +1,12 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ipfwd-bridge
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "bridge",
+    "bridge": "ipfwdbr",
+    "ipam": {
+    }
+  }'

--- a/examples/network_functions/vpp-ip-forwarder/vpp/templates/configmap.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/templates/configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vpp-configmap
+  labels:
+    app: vpp
+    chart: vpp-0.1.0
+data:
+{{ range $k, $v := .Values.cnf }}
+  setup_{{$k}}.gate: |-
+    create host-interface name net1
+    set int state host-net1 up
+  startup_{{$k}}.conf: |-
+    unix {
+      nodaemon
+      interactive
+      log /var/log/vpp/vpp.log
+      full-coredump
+      cli-listen /run/vpp/cli.sock
+      gid vpp
+      startup-config /etc/vpp/setup.gate
+    }
+
+    api-trace {
+      on
+    }
+
+    api-segment {
+      gid vpp
+    }
+
+    cpu {
+      main-core {{ .main_core }}
+      corelist-workers {{ .worker_cores }}
+    }
+
+    plugins {
+      plugin default { enable }
+      plugin memif_plugin.so { enable }
+      plugin ping_plugin.so { enable }
+    }
+{{ end }}

--- a/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
@@ -23,12 +23,15 @@ spec:
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           securityContext:
             privileged: {{ $.Values.privileged }}
-          resources:
-{{ toYaml $.Values.resources | indent 12 }}
           readinessProbe:
             exec:
               command: ["vppctl", "show ver"]
             initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["vppctl", "show ver"]
+            initialDelaySeconds: 10
             periodSeconds: 30
           volumeMounts:
           - name: config-volume
@@ -39,8 +42,6 @@ spec:
             mountPath: /etc/vpp/setup.gate
           - name: vpp-sockets
             mountPath: {{ $.Values.volumeMounts.vpp_sockets.mountPath }}
-          - name: hugepage
-            mountPath: /hugepages
       {{ end }}
       volumes:
         - name: config-volume
@@ -53,9 +54,6 @@ spec:
             - key: setup_{{$k}}.gate
               path: setup_{{$k}}.gate
             {{ end }}
-        - name: hugepage
-          emptyDir:
-            medium: HugePages
         - name: vpp-sockets
           hostPath:
             path: /etc/vpp/sockets/

--- a/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
@@ -1,52 +1,61 @@
-{{ range $k, $v := .Values.cnf }}
----
-apiVersion: v1 
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: vpp-{{$k}}
+  name: {{ $.Chart.Name }}
   labels:
-    app: vpp
-    chart: vpp-0.1.0
-  annotations:
-    k8s.v1.cni.cncf.io/networks: ipfwd-bridge
+    app: {{ $.Chart.Name }}
 spec:
-  containers:    
-  - name: {{ $.Chart.Name }}-{{$k}}
-    image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-    imagePullPolicy: {{ $.Values.image.pullPolicy }}
-    securityContext:
-      privileged: {{ $.Values.privileged }}
-    resources:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $.Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Chart.Name }}
+      annotations:
+        k8s.v1.cni.cncf.io/networks: ipfwd-bridge
+    spec:
+      containers:
+      {{ range $k, $v := .Values.cnf }}
+        - name: {{ $.Chart.Name }}-{{$k}}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          securityContext:
+            privileged: {{ $.Values.privileged }}
+          resources:
 {{ toYaml $.Values.resources | indent 12 }}
-    readinessProbe:
-      exec:
-        command: ["vppctl", "show ver"]
-      initialDelaySeconds: 5
-      periodSeconds: 30
-    volumeMounts:
-    - name: config-volume
-      subPath: startup_{{$k}}.conf
-      mountPath: /etc/vpp/startup.conf
-    - name: config-volume
-      subPath: setup_{{$k}}.gate
-      mountPath: /etc/vpp/setup.gate
-    - name: vpp-sockets
-      mountPath: {{ $.Values.volumeMounts.vpp_sockets.mountPath }}
-    - name: hugepage
-      mountPath: /hugepages
-  volumes:
-  - name: config-volume
-    configMap:
-      name: vpp-configmap
-      items:
-      - key: startup_{{$k}}.conf
-        path: startup_{{$k}}.conf
-      - key: setup_{{$k}}.gate
-        path: setup_{{$k}}.gate
-  - name: hugepage
-    emptyDir:
-      medium: HugePages
-  - name: vpp-sockets
-    hostPath:
-      path: /etc/vpp/sockets/
-{{ end }}
+          readinessProbe:
+            exec:
+              command: ["vppctl", "show ver"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          volumeMounts:
+          - name: config-volume
+            subPath: startup_{{$k}}.conf
+            mountPath: /etc/vpp/startup.conf
+          - name: config-volume
+            subPath: setup_{{$k}}.gate
+            mountPath: /etc/vpp/setup.gate
+          - name: vpp-sockets
+            mountPath: {{ $.Values.volumeMounts.vpp_sockets.mountPath }}
+          - name: hugepage
+            mountPath: /hugepages
+      {{ end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: vpp-configmap
+            items:
+            {{ range $k, $v := .Values.cnf }}
+            - key: startup_{{$k}}.conf
+              path: startup_{{$k}}.conf
+            - key: setup_{{$k}}.gate
+              path: setup_{{$k}}.gate
+            {{ end }}
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+        - name: vpp-sockets
+          hostPath:
+            path: /etc/vpp/sockets/

--- a/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/templates/deployment.yaml
@@ -1,0 +1,52 @@
+{{ range $k, $v := .Values.cnf }}
+---
+apiVersion: v1 
+kind: Pod
+metadata:
+  name: vpp-{{$k}}
+  labels:
+    app: vpp
+    chart: vpp-0.1.0
+  annotations:
+    k8s.v1.cni.cncf.io/networks: ipfwd-bridge
+spec:
+  containers:    
+  - name: {{ $.Chart.Name }}-{{$k}}
+    image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+    imagePullPolicy: {{ $.Values.image.pullPolicy }}
+    securityContext:
+      privileged: {{ $.Values.privileged }}
+    resources:
+{{ toYaml $.Values.resources | indent 12 }}
+    readinessProbe:
+      exec:
+        command: ["vppctl", "show ver"]
+      initialDelaySeconds: 5
+      periodSeconds: 30
+    volumeMounts:
+    - name: config-volume
+      subPath: startup_{{$k}}.conf
+      mountPath: /etc/vpp/startup.conf
+    - name: config-volume
+      subPath: setup_{{$k}}.gate
+      mountPath: /etc/vpp/setup.gate
+    - name: vpp-sockets
+      mountPath: {{ $.Values.volumeMounts.vpp_sockets.mountPath }}
+    - name: hugepage
+      mountPath: /hugepages
+  volumes:
+  - name: config-volume
+    configMap:
+      name: vpp-configmap
+      items:
+      - key: startup_{{$k}}.conf
+        path: startup_{{$k}}.conf
+      - key: setup_{{$k}}.gate
+        path: setup_{{$k}}.gate
+  - name: hugepage
+    emptyDir:
+      medium: HugePages
+  - name: vpp-sockets
+    hostPath:
+      path: /etc/vpp/sockets/
+{{ end }}

--- a/examples/network_functions/vpp-ip-forwarder/vpp/values.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/values.yaml
@@ -1,0 +1,25 @@
+
+privileged: true
+
+image:
+  repository: soelvkaer/vppcontainer
+  tag: latest
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: "3"
+    hugepages-2Mi: 200Mi
+
+volumeMounts:
+  vpp_sockets:
+    mountPath: /root/sockets
+
+cnf:
+  1:
+    main_core: 8
+    worker_cores: '12,38'
+
+#  2:
+#    main_core: 10
+#    worker_cores: '14,40'

--- a/examples/network_functions/vpp-ip-forwarder/vpp/values.yaml
+++ b/examples/network_functions/vpp-ip-forwarder/vpp/values.yaml
@@ -1,15 +1,10 @@
 
-privileged: true
+privileged: false
 
 image:
   repository: soelvkaer/vppcontainer
   tag: latest
   pullPolicy: IfNotPresent
-
-resources:
-  limits:
-    cpu: "3"
-    hugepages-2Mi: 200Mi
 
 volumeMounts:
   vpp_sockets:


### PR DESCRIPTION
## Description
Helm chart for deploying basic VPP container(s). Each container is attached to a host bridge, and the interface from there is added to VPP inside the container.

## Issues:
#346 

## How Has This Been Tested?
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.