### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/comparison/ansible/packet_generator.yml
+++ b/comparison/ansible/packet_generator.yml
@@ -42,7 +42,7 @@
     pip:
       name: docker-py
   - name: Install kernel headers
-    shell: "apt-get -y install linux-headers-$(uname -r)"
+    shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
     when: intel 
   - name: Get bond interface slaves
     setup:

--- a/comparison/ansible/packet_generator.yml
+++ b/comparison/ansible/packet_generator.yml
@@ -42,7 +42,7 @@
     pip:
       name: docker-py
   - name: Install kernel headers
-    shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
+    shell: "apt-get --no-install-recommends install -y apt-utils ca-certificates linux-headers-$(uname -r)"
     when: intel 
   - name: Get bond interface slaves
     setup:

--- a/comparison/ansible/packet_generator_quad_intel.yml
+++ b/comparison/ansible/packet_generator_quad_intel.yml
@@ -31,7 +31,7 @@
     pip:
       name: docker-py
   - name: Install kernel headers
-    shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
+    shell: "apt-get --no-install-recommends install -y apt-utils ca-certificates linux-headers-$(uname -r)"
   - name: Get bond interface slaves
     setup:
       filter: "{{ ansible_bond0.slaves }}"

--- a/comparison/ansible/packet_generator_quad_intel.yml
+++ b/comparison/ansible/packet_generator_quad_intel.yml
@@ -31,7 +31,7 @@
     pip:
       name: docker-py
   - name: Install kernel headers
-    shell: "apt-get -y install linux-headers-$(uname -r)"
+    shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
   - name: Get bond interface slaves
     setup:
       filter: "{{ ansible_bond0.slaves }}"

--- a/comparison/ansible/roles/multus_cni/files/vf_setup.sh
+++ b/comparison/ansible/roles/multus_cni/files/vf_setup.sh
@@ -10,7 +10,7 @@ function logtime() {
 logfile=/var/log/port_setup.log
 
 if [ ! -e "/usr/bin/lspci" ]; then
-  apt-get install pciutils -y
+  apt-get --no-install-recommends install -y pciutils
 fi
 
 pf_ids=($(lspci | grep Eth | grep -v Virtual | awk '{print $1}' | head -n 3 | tail -n 2))

--- a/comparison/ansible/roles/multus_cni/files/vf_setup.sh
+++ b/comparison/ansible/roles/multus_cni/files/vf_setup.sh
@@ -10,7 +10,7 @@ function logtime() {
 logfile=/var/log/port_setup.log
 
 if [ ! -e "/usr/bin/lspci" ]; then
-  apt-get --no-install-recommends install -y pciutils
+  apt-get --no-install-recommends install -y apt-utils ca-certificates pciutils
 fi
 
 pf_ids=($(lspci | grep Eth | grep -v Virtual | awk '{print $1}' | head -n 3 | tail -n 2))

--- a/comparison/ansible/roles/nfvbench_ipv6_intel/tasks/main.yml
+++ b/comparison/ansible/roles/nfvbench_ipv6_intel/tasks/main.yml
@@ -8,7 +8,7 @@
     name: zlib1g-dev
 
 - name: Install kernel headers
-  shell: "apt-get -y install linux-headers-$(uname -r)"
+  shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
 
 - name: Check if TRex has been cloned
   stat:

--- a/comparison/ansible/roles/nfvbench_ipv6_intel/tasks/main.yml
+++ b/comparison/ansible/roles/nfvbench_ipv6_intel/tasks/main.yml
@@ -8,7 +8,7 @@
     name: zlib1g-dev
 
 - name: Install kernel headers
-  shell: "apt-get --no-install-recommends install -y linux-headers-$(uname -r)"
+  shell: "apt-get --no-install-recommends install -y apt-utils ca-certificates linux-headers-$(uname -r)"
 
 - name: Check if TRex has been cloned
   stat:

--- a/comparison/ansible/roles/retr0h.etcd/.travis.yml
+++ b/comparison/ansible/roles/retr0h.etcd/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get --no-install-recommends install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine
+  - sudo apt-get --no-install-recommends install -y apt-utils ca-certificates -o Dpkg::Options::="--force-confold" --force-yes docker-engine
 
 install:
   - make

--- a/comparison/ansible/roles/retr0h.etcd/.travis.yml
+++ b/comparison/ansible/roles/retr0h.etcd/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+  - sudo apt-get --no-install-recommends install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine
 
 install:
   - make

--- a/comparison/ansible/roles/visualization/files/fluentd.dockerfile
+++ b/comparison/ansible/roles/visualization/files/fluentd.dockerfile
@@ -3,5 +3,5 @@ FROM fluent/fluentd:v1.6-debian-1
 USER root
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.2"]
 RUN apt-get update \
-  && apt-get install curl -y
+  && apt-get --no-install-recommends install -y curl -y
 USER fluent

--- a/comparison/ansible/roles/visualization/files/fluentd.dockerfile
+++ b/comparison/ansible/roles/visualization/files/fluentd.dockerfile
@@ -3,5 +3,5 @@ FROM fluent/fluentd:v1.6-debian-1
 USER root
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.2"]
 RUN apt-get update \
-  && apt-get --no-install-recommends install -y curl -y
+  && apt-get --no-install-recommends install -y apt-utils ca-certificates curl
 USER fluent

--- a/comparison/ansible/roles/visualization/templates/Dockerfile.j2
+++ b/comparison/ansible/roles/visualization/templates/Dockerfile.j2
@@ -3,5 +3,5 @@ FROM fluent/fluentd:v1.6-debian-1
 USER root
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.2"]
 RUN apt-get update \
-  && apt-get install curl -y
+  && apt-get --no-install-recommends install -y curl
 USER fluent

--- a/comparison/ansible/roles/visualization/templates/Dockerfile.j2
+++ b/comparison/ansible/roles/visualization/templates/Dockerfile.j2
@@ -3,5 +3,5 @@ FROM fluent/fluentd:v1.6-debian-1
 USER root
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.2"]
 RUN apt-get update \
-  && apt-get --no-install-recommends install -y curl
+  && apt-get --no-install-recommends install -y apt-utils ca-certificates curl
 USER fluent

--- a/comparison/ansible/roles/vpp_src_install/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_src_install/tasks/main.yml
@@ -126,7 +126,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Install vpp packages
-  command: apt-get --no-install-recommends install -y {{item.path}}
+  command: apt-get --no-install-recommends install -y apt-utils ca-certificates {{item.path}}
   with_items: "{{vpp['files']}}"
   when: ansible_os_family == 'Debian'
 

--- a/comparison/ansible/roles/vpp_src_install/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_src_install/tasks/main.yml
@@ -126,7 +126,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Install vpp packages
-  command: apt install {{item.path}}
+  command: apt-get --no-install-recommends install -y {{item.path}}
   with_items: "{{vpp['files']}}"
   when: ansible_os_family == 'Debian'
 
@@ -137,7 +137,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Install vpp plugins packages
-  command: apt install {{item.path}}
+  command: apt-get --no-install-recommends install -y {{item.path}}
   with_items: "{{vpp_plugin['files']}}"
   when: ansible_os_family == 'Debian'
 
@@ -148,7 +148,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Install vpp api python packages
-  command: apt install {{item.path}}
+  command: apt-get --no-install-recommends install -y {{item.path}}
   with_items: "{{vpp_api_python['files']}}"
   when: ansible_os_family == 'Debian'
 

--- a/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/README.md
+++ b/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/README.md
@@ -43,7 +43,7 @@ Once this is done the server can be restarted using `reboot`
 Find the PCI devices that will be used for traffic
 ```
 lspci | grep Eth
-  - Run 'apt install pciutils' if lspci is not installed
+  - Run 'apt-get --no-install-recommends install -y pciutils' if lspci is not installed
   5e:00.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.1 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
 ```

--- a/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/install_vpp.sh
+++ b/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/install_vpp.sh
@@ -139,7 +139,7 @@ function install_vpp () {
         artifacts+=(${vpp[@]/%/=${vpp_version-}})
     fi
     curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | sudo bash
-    sudo apt-get --no-install-recommends install -y "${artifacts[@]}" || die "VPP installation failed!"
+    sudo apt-get --no-install-recommends install -y apt-utils ca-certificates "${artifacts[@]}" || die "VPP installation failed!"
     sleep 1
 
     if installed vpp; then

--- a/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/install_vpp.sh
+++ b/comparison/baseline_nf_performance-csit/cnf_edge_router/vpp_vswitch/install_vpp.sh
@@ -139,7 +139,7 @@ function install_vpp () {
         artifacts+=(${vpp[@]/%/=${vpp_version-}})
     fi
     curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | sudo bash
-    sudo apt-get install -y "${artifacts[@]}" || die "VPP installation failed!"
+    sudo apt-get --no-install-recommends install -y "${artifacts[@]}" || die "VPP installation failed!"
     sleep 1
 
     if installed vpp; then

--- a/comparison/baseline_nf_performance-csit/install_docker_prereqs.sh
+++ b/comparison/baseline_nf_performance-csit/install_docker_prereqs.sh
@@ -2,7 +2,7 @@
 
 sudo apt-get update
 
-sudo apt-get install -y  \
+sudo apt-get --no-install-recommends install -y  \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -18,7 +18,7 @@ sudo add-apt-repository -y  \
 
 sudo apt-get update
 
-sudo apt-get install -y docker-ce
+sudo apt-get --no-install-recommends install -y docker-ce
 
 # Prepare Hugepages
 echo "Setting up hugepages memory support"

--- a/comparison/baseline_nf_performance-csit/install_vagrant_prereqs.sh
+++ b/comparison/baseline_nf_performance-csit/install_vagrant_prereqs.sh
@@ -15,7 +15,7 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y apt-utils ca-certificates qemu libvirt-bin ebtables dnsmasq
 apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt --plugin-version 0.0.43

--- a/comparison/baseline_nf_performance-csit/install_vagrant_prereqs.sh
+++ b/comparison/baseline_nf_performance-csit/install_vagrant_prereqs.sh
@@ -15,8 +15,8 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get install -y qemu libvirt-bin ebtables dnsmasq
-apt-get install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
+apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt --plugin-version 0.0.43
 vagrant plugin install vagrant-disksize --plugin-version 0.1.2

--- a/comparison/baseline_nf_performance-csit/packet_generator/README.md
+++ b/comparison/baseline_nf_performance-csit/packet_generator/README.md
@@ -70,7 +70,7 @@ Run `source ~/.bashrc` to apply the alias.
 Find the PCI devices that will be used for traffic
 ```
 lspci | grep Eth
-  - Run 'apt install pciutils' if lspci is not installed
+  - Run 'apt-get --no-install-recommends install -y pciutils' if lspci is not installed
   5e:00.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.1 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.4 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx Virtual Function] (*)

--- a/comparison/baseline_nf_performance-csit/vEdge/CNF/CSC_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-csit/vEdge/CNF/CSC_multichain_shared/Dockerfile
@@ -7,7 +7,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get install --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
         make \
         gcc \
         libcurl4-openssl-dev \
@@ -21,7 +21,7 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         vpp=18.10-release \
         vpp-dbg=18.10-release\
         vpp-dev=18.10-release\

--- a/comparison/baseline_nf_performance-csit/vEdge/CNF/CSC_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-csit/vEdge/CNF/CSC_multichain_shared/Dockerfile
@@ -7,7 +7,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated \
         make \
         gcc \
         libcurl4-openssl-dev \

--- a/comparison/baseline_nf_performance-csit/vEdge/CNF/CSP_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-csit/vEdge/CNF/CSP_multichain_shared/Dockerfile
@@ -7,7 +7,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get install --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
         make \
         gcc \
         libcurl4-openssl-dev \
@@ -21,7 +21,7 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         vpp=18.10-release \
         vpp-dbg=18.10-release\
         vpp-dev=18.10-release\

--- a/comparison/baseline_nf_performance-csit/vEdge/CNF/CSP_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-csit/vEdge/CNF/CSP_multichain_shared/Dockerfile
@@ -7,7 +7,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated \
         make \
         gcc \
         libcurl4-openssl-dev \

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/build_vm.sh
@@ -18,7 +18,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/build_vm.sh
@@ -18,7 +18,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
@@ -7,7 +7,7 @@ set -o xtrace  # print commands during script execution
 if [ "$VEDGE_STATE" == "build" ];
 then 
     sudo apt-get update -y
-    sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+    sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
     pip install jsonschema
 
     sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
@@ -7,10 +7,10 @@ set -o xtrace  # print commands during script execution
 if [ "$VEDGE_STATE" == "build" ];
 then 
     sudo apt-get update -y
-    sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+    sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
     pip install jsonschema
 
-    sudo apt-get -y install linux-headers-$(uname -r)
+    sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
     # Install VPP
     export UBUNTU="xenial"
@@ -18,7 +18,7 @@ then
     sudo rm /etc/apt/sources.list.d/99fd.io.list
     sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
     sudo apt-get update
-    sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+    sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
     sleep 1
 
     sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/build_vm.sh
@@ -15,7 +15,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/build_vm.sh
@@ -15,7 +15,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 VPP_VERSION="18.10-release"
@@ -17,7 +17,7 @@ else
     artifacts+=(${vpp[@]/%/=${VPP_VERSION-}})
 fi
 curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
-apt-get install -y "${artifacts[@]}"
+apt-get --no-install-recommends install -y "${artifacts[@]}"
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-csit/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/README.md
+++ b/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/README.md
@@ -43,7 +43,7 @@ Once this is done the server can be restarted using `reboot`
 Find the PCI devices that will be used for traffic
 ```
 lspci | grep Eth
-  - Run 'apt install pciutils' if lspci is not installed
+  - Run 'apt-get --no-install-recommends install -y pciutils' if lspci is not installed
   5e:00.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.1 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
 ```

--- a/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/install_vpp.sh
+++ b/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/install_vpp.sh
@@ -148,7 +148,7 @@ function install_vpp_intel () {
         artifacts+=(${vpp[@]/%/=${VPP_VERSION-}})
     fi
     curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | sudo bash
-    sudo apt-get --no-install-recommends install -y "${artifacts[@]}" || die "VPP installation failed!"
+    sudo apt-get --no-install-recommends install -y apt-utils ca-certificates "${artifacts[@]}" || die "VPP installation failed!"
     sleep 1
 
     if installed vpp; then

--- a/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/install_vpp.sh
+++ b/comparison/baseline_nf_performance-packet/cnf_edge_router/vpp_vswitch/install_vpp.sh
@@ -148,7 +148,7 @@ function install_vpp_intel () {
         artifacts+=(${vpp[@]/%/=${VPP_VERSION-}})
     fi
     curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | sudo bash
-    sudo apt-get install -y "${artifacts[@]}" || die "VPP installation failed!"
+    sudo apt-get --no-install-recommends install -y "${artifacts[@]}" || die "VPP installation failed!"
     sleep 1
 
     if installed vpp; then
@@ -176,7 +176,7 @@ function install_vpp_mlx () {
 
     # Check for git
     if ! installed git; then
-        apt install git
+        apt-get --no-install-recommends install -y git
     fi
 
     # Build and install VPP

--- a/comparison/baseline_nf_performance-packet/host_vpp_container/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/host_vpp_container/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 ENV VPP_VER "19.04.1"
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     vlan \
     vim \
     curl \
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
     dpdk \
     vpp=${VPP_VER}-release \
     vpp-plugin-core=${VPP_VER}-release \

--- a/comparison/baseline_nf_performance-packet/host_vpp_container/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/host_vpp_container/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 ENV VPP_VER "19.04.1"
 
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     vlan \
     vim \
     curl \

--- a/comparison/baseline_nf_performance-packet/host_vpp_container/README.md
+++ b/comparison/baseline_nf_performance-packet/host_vpp_container/README.md
@@ -29,7 +29,7 @@ _Installation steps taken from [docker.com](https://docs.docker.com/install/linu
 ```
 apt-get update
 
-apt-get install \
+apt-get --no-install-recommends install -y \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -45,7 +45,7 @@ add-apt-repository \
 
 apt-get update
 
-apt-get install docker-ce docker-ce-cli containerd.io
+apt-get --no-install-recommends install -y docker-ce docker-ce-cli containerd.io
 ```
 
 ### Build and run VPP container

--- a/comparison/baseline_nf_performance-packet/install_docker_prereqs.sh
+++ b/comparison/baseline_nf_performance-packet/install_docker_prereqs.sh
@@ -2,7 +2,7 @@
 
 sudo apt-get update
 
-sudo apt-get install -y  \
+sudo apt-get --no-install-recommends install -y  \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -18,7 +18,7 @@ sudo add-apt-repository -y  \
 
 sudo apt-get update
 
-sudo apt-get install -y docker-ce
+sudo apt-get --no-install-recommends install -y docker-ce
 
 # Prepare Hugepages
 echo "Setting up hugepages memory support"

--- a/comparison/baseline_nf_performance-packet/install_vagrant_prereqs.sh
+++ b/comparison/baseline_nf_performance-packet/install_vagrant_prereqs.sh
@@ -15,7 +15,7 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y apt-utils ca-certificates qemu libvirt-bin ebtables dnsmasq
 apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt --plugin-version 0.0.43

--- a/comparison/baseline_nf_performance-packet/install_vagrant_prereqs.sh
+++ b/comparison/baseline_nf_performance-packet/install_vagrant_prereqs.sh
@@ -15,8 +15,8 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get install -y qemu libvirt-bin ebtables dnsmasq
-apt-get install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
+apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt --plugin-version 0.0.43
 vagrant plugin install vagrant-disksize --plugin-version 0.1.2

--- a/comparison/baseline_nf_performance-packet/packet_generator/README.md
+++ b/comparison/baseline_nf_performance-packet/packet_generator/README.md
@@ -109,7 +109,7 @@ Run `source ~/.bashrc` to apply the alias.
 Find the PCI devices that will be used for traffic
 ```
 lspci | grep Eth
-  - Run 'apt install pciutils' if lspci is not installed
+  - Run 'apt-get --no-install-recommends install -y pciutils' if lspci is not installed
   5e:00.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.1 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.4 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx Virtual Function] (*)

--- a/comparison/baseline_nf_performance-packet/rdma_host_vpp_container/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/rdma_host_vpp_container/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt update && apt install -y \
+RUN apt update && apt-get --no-install-recommends install -y \
     sudo \
     make \
     git \

--- a/comparison/baseline_nf_performance-packet/rdma_host_vpp_container/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/rdma_host_vpp_container/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     sudo \
     make \
     git \

--- a/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated \
         make \
         gcc \
         libcurl4-openssl-dev \

--- a/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get install --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
         make \
         gcc \
         libcurl4-openssl-dev \
@@ -23,7 +23,7 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         dpdk \
         vpp=${VPP_VER}-release \
         vpp-plugin-core=${VPP_VER}-release \

--- a/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/create_vpp_config.sh
@@ -230,7 +230,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ ! -z "$(apt-cache policy pciutils | grep "Installed: (none)")" ]; then
     warn "Installing pciutils"
-    apt update && apt install -y pciutils
+    apt update && apt-get --no-install-recommends install -y pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/use_case_pocs/ipsec/create_vpp_config.sh
@@ -230,7 +230,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ ! -z "$(apt-cache policy pciutils | grep "Installed: (none)")" ]; then
     warn "Installing pciutils"
-    apt update && apt-get --no-install-recommends install -y pciutils
+    apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated \
         make \
         gcc \
         libcurl4-openssl-dev \

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get install --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
         make \
         gcc \
         libcurl4-openssl-dev \
@@ -23,7 +23,7 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         dpdk \
         vpp=${VPP_VER}-release \
         vpp-plugin-core=${VPP_VER}-release \

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/create_vpp_config.sh
@@ -245,7 +245,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ -z "$(apt-cache policy pciutils | grep Installed)" ]; then
     warn "Installing pciutils"
-    apt update && apt-get --no-install-recommends install -y pciutils
+    apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSC_multichain_shared/create_vpp_config.sh
@@ -245,7 +245,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ -z "$(apt-cache policy pciutils | grep Installed)" ]; then
     warn "Installing pciutils"
-    apt update && apt install pciutils
+    apt update && apt-get --no-install-recommends install -y pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated \
         make \
         gcc \
         libcurl4-openssl-dev \

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/Dockerfile
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/Dockerfile
@@ -9,7 +9,7 @@ CMD mkdir ~/sockets
 CMD tail -f /dev/null
 
 RUN apt-get update -y && \
-    apt-get install --allow-unauthenticated -y \
+    apt-get --no-install-recommends install -y --allow-unauthenticated -y \
         make \
         gcc \
         libcurl4-openssl-dev \
@@ -23,7 +23,7 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         dpdk \
         vpp=${VPP_VER}-release \
         vpp-plugin-core=${VPP_VER}-release \

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/create_vpp_config.sh
@@ -231,7 +231,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ -z "$(apt-cache policy pciutils | grep Installed)" ]; then
     warn "Installing pciutils"
-    apt update && apt install pciutils
+    apt update && apt-get --no-install-recommends install -y pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/create_vpp_config.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/CNF/CSP_multichain_shared/create_vpp_config.sh
@@ -231,7 +231,7 @@ validate_input "${@}" || die
 clean_vpp_config || die
 if [ -z "$(apt-cache policy pciutils | grep Installed)" ]; then
     warn "Installing pciutils"
-    apt update && apt-get --no-install-recommends install -y pciutils
+    apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates pciutils
 fi
 if detect_mellanox; then
     # This is most probably Packet mlx env

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/build_vm.sh
@@ -18,7 +18,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/build_vm.sh
@@ -18,7 +18,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
@@ -7,7 +7,7 @@ set -o xtrace  # print commands during script execution
 if [ "$VEDGE_STATE" == "build" ];
 then 
     sudo apt-get update -y
-    sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+    sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
     pip install jsonschema
 
     sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_openstack/base_image/vedge_vm_build.sh
@@ -7,10 +7,10 @@ set -o xtrace  # print commands during script execution
 if [ "$VEDGE_STATE" == "build" ];
 then 
     sudo apt-get update -y
-    sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+    sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
     pip install jsonschema
 
-    sudo apt-get -y install linux-headers-$(uname -r)
+    sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
     # Install VPP
     export UBUNTU="xenial"
@@ -18,7 +18,7 @@ then
     sudo rm /etc/apt/sources.list.d/99fd.io.list
     sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
     sudo apt-get update
-    sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+    sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
     sleep 1
 
     sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/build_vm.sh
@@ -15,7 +15,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/build_vm.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/build_vm.sh
@@ -15,7 +15,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 VPP_VERSION="18.10-release"
@@ -17,7 +17,7 @@ else
     artifacts+=(${vpp[@]/%/=${VPP_VERSION-}})
 fi
 curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
-apt-get install -y "${artifacts[@]}"
+apt-get --no-install-recommends install -y "${artifacts[@]}"
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
+++ b/comparison/baseline_nf_performance-packet/vEdge/VNF_vagrant/base_image/vedge_vm_build.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/box-by-box-kvm-docker/Pktgen/bootstrap.sh
+++ b/comparison/box-by-box-kvm-docker/Pktgen/bootstrap.sh
@@ -11,10 +11,10 @@ set -ex
 #sudo ./setup_intel_proxy.sh
 
 sudo apt-get update -y
-sudo apt-get install linux-headers-$(uname -r) -y
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r) -y
 
 sudo apt-get remove docker docker-engine docker.io -y
-sudo apt-get install \
+sudo apt-get --no-install-recommends install -y \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -33,7 +33,7 @@ sudo add-apt-repository \
  
 sudo apt-get update
 
-sudo apt-get install docker-ce -y
+sudo apt-get --no-install-recommends install -y docker-ce -y
 
 lspci | grep Ethernet
 

--- a/comparison/box-by-box-kvm-docker/Pktgen/bootstrap.sh
+++ b/comparison/box-by-box-kvm-docker/Pktgen/bootstrap.sh
@@ -11,7 +11,7 @@ set -ex
 #sudo ./setup_intel_proxy.sh
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r) -y
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 sudo apt-get remove docker docker-engine docker.io -y
 sudo apt-get --no-install-recommends install -y \
@@ -33,7 +33,7 @@ sudo add-apt-repository \
  
 sudo apt-get update
 
-sudo apt-get --no-install-recommends install -y docker-ce -y
+sudo apt-get --no-install-recommends install -y docker-ce
 
 lspci | grep Ethernet
 

--- a/comparison/box-by-box-kvm-docker/install_docker_prereqs.sh
+++ b/comparison/box-by-box-kvm-docker/install_docker_prereqs.sh
@@ -2,7 +2,7 @@
 
 sudo apt-get update
 
-sudo apt-get install -y  \
+sudo apt-get --no-install-recommends install -y  \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -18,7 +18,7 @@ sudo add-apt-repository -y  \
 
 sudo apt-get update
 
-sudo apt-get install -y docker-ce
+sudo apt-get --no-install-recommends install -y docker-ce
 
 # Prepare Hugepages
 echo "Setting up hugepages memory support"

--- a/comparison/box-by-box-kvm-docker/install_kvm_prereqs.sh
+++ b/comparison/box-by-box-kvm-docker/install_kvm_prereqs.sh
@@ -16,7 +16,7 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y apt-utils ca-certificates qemu libvirt-bin ebtables dnsmasq
 apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt

--- a/comparison/box-by-box-kvm-docker/install_kvm_prereqs.sh
+++ b/comparison/box-by-box-kvm-docker/install_kvm_prereqs.sh
@@ -16,8 +16,8 @@ popd
 apt-get update
 ## Ubuntu 18.04 does not have source repos enabled, but does not seem to need them for the libvirt plugin
 #apt-get build-dep vagrant ruby-libvirt
-apt-get install -y qemu libvirt-bin ebtables dnsmasq
-apt-get install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
+apt-get --no-install-recommends install -y qemu libvirt-bin ebtables dnsmasq
+apt-get --no-install-recommends install -y libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
 vagrant plugin install vagrant-libvirt
 

--- a/comparison/box-by-box-kvm-docker/install_vpp_prereqs.sh
+++ b/comparison/box-by-box-kvm-docker/install_vpp_prereqs.sh
@@ -34,7 +34,7 @@ curl -L https://packagecloud.io/fdio/release/gpgkey |sudo apt-key add -
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu/ bionic main" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
+apt-get --no-install-recommends install -y vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
 
 config_sysctl
 
@@ -48,7 +48,7 @@ if [ "$DISTRIB_CODENAME" == "bionic" ]; then
   rm /etc/apt/sources.list.d/99fd.io.list
   echo "deb [trusted=yes] https://packagecloud.io/fdio/1807/ubuntu/ bionic main" | tee -a /etc/apt/sources.list.d/99fd.io.list
   apt-get update
-  apt-get install vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
+  apt-get --no-install-recommends install -y vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
 elif [ "$DISTRIB_CODENAME" == "xenial" ]; then
   # Install VPP 18.04 (stable)
   export UBUNTU="xenial"
@@ -56,7 +56,7 @@ elif [ "$DISTRIB_CODENAME" == "xenial" ]; then
   rm /etc/apt/sources.list.d/99fd.io.list
   echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
   sudo apt-get update
-  apt-get install vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
+  apt-get --no-install-recommends install -y vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
   touch /etc/vpp/setup.gate
   sed -i '8i\  startup-config /etc/vpp/setup.gate' /etc/vpp/startup.conf
   config_sysctl

--- a/comparison/box-by-box-kvm-docker/install_vpp_prereqs.sh
+++ b/comparison/box-by-box-kvm-docker/install_vpp_prereqs.sh
@@ -34,7 +34,7 @@ curl -L https://packagecloud.io/fdio/release/gpgkey |sudo apt-key add -
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu/ bionic main" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get --no-install-recommends install -y vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
+apt-get --no-install-recommends install -y apt-utils ca-certificates vpp vpp-lib vpp-plugins vpp-dbg vpp-dev vpp-api-java vpp-api-python vpp-api-lua
 
 config_sysctl
 

--- a/comparison/box-by-box-kvm-docker/vBNG/Container/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/Container/cnf_vbng_install.sh
@@ -4,7 +4,7 @@
 cd /vBNG
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -13,7 +13,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 bash -c "cat > /etc/vpp/startup.conf" <<EOF

--- a/comparison/box-by-box-kvm-docker/vBNG/Container/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/Container/cnf_vbng_install.sh
@@ -4,7 +4,7 @@
 cd /vBNG
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/v_bng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/v_bng_install.sh
@@ -15,10 +15,10 @@ sudo cp v_bng.sh /etc/init.d
 sudo update-rc.d v_bng.sh defaults
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 export UBUNTU="xenial"
@@ -26,7 +26,7 @@ export RELEASE=".stable.1804"
 sudo rm /etc/apt/sources.list.d/99fd.io.list
 sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 sudo apt-get update
-sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/v_bng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/v_bng_install.sh
@@ -15,7 +15,7 @@ sudo cp v_bng.sh /etc/init.d
 sudo update-rc.d v_bng.sh defaults
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/vnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/vnf_vbng_install.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 #sudo apt-get update -y
-#sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+#sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 #pip install jsonschema
 
 #sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/vnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/SRIOV_VM/vnf_vbng_install.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 #sudo apt-get update -y
-#sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+#sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 #pip install jsonschema
 
-#sudo apt-get -y install linux-headers-$(uname -r)
+#sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 #export UBUNTU="xenial"
@@ -13,7 +13,7 @@ set -o xtrace  # print commands during script execution
 #sudo rm /etc/apt/sources.list.d/99fd.io.list
 #sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 #sudo apt-get update
-#sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+#sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 #sleep 1
 
 #sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/box-by-box-kvm-docker/vBNG/v_bng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/v_bng_install.sh
@@ -15,10 +15,10 @@ sudo cp v_bng.sh /etc/init.d
 sudo update-rc.d v_bng.sh defaults
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 export UBUNTU="xenial"
@@ -26,7 +26,7 @@ export RELEASE=".stable.1804"
 sudo rm /etc/apt/sources.list.d/99fd.io.list
 sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 sudo apt-get update
-sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/box-by-box-kvm-docker/vBNG/v_bng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG/v_bng_install.sh
@@ -15,7 +15,7 @@ sudo cp v_bng.sh /etc/init.d
 sudo update-rc.d v_bng.sh defaults
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/cnf_vbng_install.sh
@@ -4,7 +4,7 @@
 cd /vBNG
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/cnf_vbng_install.sh
@@ -4,7 +4,7 @@
 cd /vBNG
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -14,7 +14,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 bash -c "cat > /etc/vpp/startup.conf" <<EOF

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/1st/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/1st/cnf_vbng_install.sh
@@ -5,7 +5,7 @@ cd /vBNG
 mkdir ~/sockets
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -15,7 +15,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 bash -c "cat > /etc/vpp/startup.conf" <<EOF

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/1st/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/1st/cnf_vbng_install.sh
@@ -5,7 +5,7 @@ cd /vBNG
 mkdir ~/sockets
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/2nd/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/2nd/cnf_vbng_install.sh
@@ -5,7 +5,7 @@ cd /vBNG
 mkdir ~/sockets
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -15,7 +15,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 bash -c "cat > /etc/vpp/startup.conf" <<EOF

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/2nd/cnf_vbng_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/2nd/cnf_vbng_install.sh
@@ -5,7 +5,7 @@ cd /vBNG
 mkdir ~/sockets
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/nchains/base/cnf_vedge_base_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/nchains/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -15,5 +15,5 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/nchains/base/cnf_vedge_base_install.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/Container/multichain/nchains/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/build_vm.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/build_vm.sh
@@ -7,7 +7,7 @@ if [ -z "$(vagrant plugin list |grep disksize)" ] ; then
   SUDO=$(which sudo)
 
   if [ -z "$(which virt-sysprep)" ] ; then
-	    $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+	    $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
     fi
 
     #Build the VM with vagrant

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/build_vm.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/build_vm.sh
@@ -7,7 +7,7 @@ if [ -z "$(vagrant plugin list |grep disksize)" ] ; then
   SUDO=$(which sudo)
 
   if [ -z "$(which virt-sysprep)" ] ; then
-	    $SUDO apt-get install -y libguestfs-tools
+	    $SUDO apt-get --no-install-recommends install -y libguestfs-tools
     fi
 
     #Build the VM with vagrant

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/vbng_vm_build.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/vbng_vm_build.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/vbng_vm_build.sh
+++ b/comparison/box-by-box-kvm-docker/vBNG_Extra/VM_build/vbng_vm_build.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 export UBUNTU="xenial"
@@ -13,7 +13,7 @@ export RELEASE=".stable.1804"
 sudo rm /etc/apt/sources.list.d/99fd.io.list
 sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 sudo apt-get update
-sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/box-by-box-kvm-docker/vDNS/build/build_vm.sh
+++ b/comparison/box-by-box-kvm-docker/vDNS/build/build_vm.sh
@@ -7,7 +7,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 #Build the VM with vagrant

--- a/comparison/box-by-box-kvm-docker/vDNS/build/build_vm.sh
+++ b/comparison/box-by-box-kvm-docker/vDNS/build/build_vm.sh
@@ -7,7 +7,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 #Build the VM with vagrant

--- a/comparison/box-by-box-kvm-docker/vDNS/build/v_dns_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNS/build/v_dns_install.sh
@@ -2,11 +2,11 @@
 
 echo "export DEBIAN_FRONTEND=noninteractive" | tee -a /etc/profile
 
-apt-get install -y sudo
-sudo apt-get install -y software-properties-common python-software-properties
+apt-get --no-install-recommends install -y sudo
+sudo apt-get --no-install-recommends install -y software-properties-common python-software-properties
 sudo add-apt-repository -s -y  ppa:openjdk-r/ppa
 sudo apt-get update
-sudo apt-get install --allow-unauthenticated -y wget openjdk-8-jdk bind9 bind9utils bind9-doc apt-transport-https ca-certificates kea-dhcp4-server g++ libcurl4-gnutls-dev libboost-dev kea-dev
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y wget openjdk-8-jdk bind9 bind9utils bind9-doc apt-transport-https ca-certificates kea-dhcp4-server g++ libcurl4-gnutls-dev libboost-dev kea-dev
 sleep 1
 
 # Download DNS and DHCP config files

--- a/comparison/box-by-box-kvm-docker/vDNS/build/v_dns_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNS/build/v_dns_install.sh
@@ -6,7 +6,7 @@ apt-get --no-install-recommends install -y sudo
 sudo apt-get --no-install-recommends install -y software-properties-common python-software-properties
 sudo add-apt-repository -s -y  ppa:openjdk-r/ppa
 sudo apt-get update
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y wget openjdk-8-jdk bind9 bind9utils bind9-doc apt-transport-https ca-certificates kea-dhcp4-server g++ libcurl4-gnutls-dev libboost-dev kea-dev
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated wget openjdk-8-jdk bind9 bind9utils bind9-doc apt-transport-https ca-certificates kea-dhcp4-server g++ libcurl4-gnutls-dev libboost-dev kea-dev
 sleep 1
 
 # Download DNS and DHCP config files

--- a/comparison/box-by-box-kvm-docker/vDNSgen/Dockerfile
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/Dockerfile
@@ -4,7 +4,7 @@ COPY . /vDNSgen
 WORKDIR /vDNSgen
 
 RUN apt-get update
-RUN apt-get install -y lshw pciutils net-tools iproute bsdmainutils
+RUN apt-get --no-install-recommends install -y lshw pciutils net-tools iproute bsdmainutils
 
 CMD tail -f /dev/null
 

--- a/comparison/box-by-box-kvm-docker/vDNSgen/Dockerfile
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/Dockerfile
@@ -4,7 +4,7 @@ COPY . /vDNSgen
 WORKDIR /vDNSgen
 
 RUN apt-get update
-RUN apt-get --no-install-recommends install -y lshw pciutils net-tools iproute bsdmainutils
+RUN apt-get --no-install-recommends install -y apt-utils ca-certificates lshw pciutils net-tools iproute bsdmainutils
 
 CMD tail -f /dev/null
 

--- a/comparison/box-by-box-kvm-docker/vDNSgen/cnf_vdnsgen_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/cnf_vdnsgen_install.sh
@@ -9,7 +9,7 @@ chmod +x cnf_dns_test.sh
 chmod +x set_dns_packet_rate.sh
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates tcpdump iputils-ping dnsutils vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates tcpdump iputils-ping dnsutils vim
 pip install jsonschema
 
 # Install VPP
@@ -18,7 +18,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 #service vpp stop

--- a/comparison/box-by-box-kvm-docker/vDNSgen/cnf_vdnsgen_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/cnf_vdnsgen_install.sh
@@ -9,7 +9,7 @@ chmod +x cnf_dns_test.sh
 chmod +x set_dns_packet_rate.sh
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates tcpdump iputils-ping dnsutils vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates tcpdump iputils-ping dnsutils vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vDNSgen/v_packetgen_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/v_packetgen_install.sh
@@ -16,7 +16,7 @@ chmod +x dns_test.sh
 chmod +x set_dns_packet_rate
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 # Install VPP

--- a/comparison/box-by-box-kvm-docker/vDNSgen/v_packetgen_install.sh
+++ b/comparison/box-by-box-kvm-docker/vDNSgen/v_packetgen_install.sh
@@ -16,7 +16,7 @@ chmod +x dns_test.sh
 chmod +x set_dns_packet_rate
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
 # Install VPP
@@ -25,7 +25,7 @@ export RELEASE=".stable.1804"
 sudo rm /etc/apt/sources.list.d/99fd.io.list
 sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 sudo apt-get update
-sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 sudo service vpp stop

--- a/comparison/kubecon18-chained_nf_test/CNF/CSC_multichain/base/cnf_vedge_base_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/CSC_multichain/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -15,5 +15,5 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1

--- a/comparison/kubecon18-chained_nf_test/CNF/CSC_multichain/base/cnf_vedge_base_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/CSC_multichain/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/kubecon18-chained_nf_test/CNF/cnf_vedge_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/cnf_vedge_install.sh
@@ -4,7 +4,7 @@
 cd /vEdge
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -14,7 +14,7 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 bash -c "cat > /etc/vpp/startup.conf" <<EOF

--- a/comparison/kubecon18-chained_nf_test/CNF/cnf_vedge_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/cnf_vedge_install.sh
@@ -4,7 +4,7 @@
 cd /vEdge
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/kubecon18-chained_nf_test/CNF/multichain/base/cnf_vedge_base_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/multichain/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP
@@ -15,5 +15,5 @@ export RELEASE=".stable.1804"
 rm /etc/apt/sources.list.d/99fd.io.list
 echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | tee -a /etc/apt/sources.list.d/99fd.io.list
 apt-get update
-apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1

--- a/comparison/kubecon18-chained_nf_test/CNF/multichain/base/cnf_vedge_base_install.sh
+++ b/comparison/kubecon18-chained_nf_test/CNF/multichain/base/cnf_vedge_base_install.sh
@@ -5,7 +5,7 @@ cd /vEdge
 mkdir ~/sockets
 
 apt-get update -y
-apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
+apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates vim
 pip install jsonschema
 
 # Install VPP

--- a/comparison/kubecon18-chained_nf_test/VNF/base_image/build_vm.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF/base_image/build_vm.sh
@@ -20,7 +20,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/kubecon18-chained_nf_test/VNF/base_image/build_vm.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF/base_image/build_vm.sh
@@ -20,7 +20,7 @@ fi
 SUDO=$(which sudo)
 
 if [ -z "$(which virt-sysprep)" ] ; then
-  $SUDO apt-get --no-install-recommends install -y libguestfs-tools
+  $SUDO apt-get --no-install-recommends install -y apt-utils ca-certificates libguestfs-tools
 fi
 
 # Build the VM with vagrant

--- a/comparison/kubecon18-chained_nf_test/VNF/base_image/vedge_vm_build.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF/base_image/vedge_vm_build.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/kubecon18-chained_nf_test/VNF/base_image/vedge_vm_build.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF/base_image/vedge_vm_build.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make wget gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates -y
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 export UBUNTU="xenial"
@@ -13,7 +13,7 @@ export RELEASE=".stable.1804"
 sudo rm /etc/apt/sources.list.d/99fd.io.list
 sudo echo "deb [trusted=yes] https://nexus.fd.io/content/repositories/fd.io$RELEASE.ubuntu.$UBUNTU.main/ ./" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list
 sudo apt-get update
-sudo apt-get install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
+sudo apt-get --no-install-recommends install -y vpp vpp-dpdk-dkms vpp-lib vpp-dbg vpp-plugins vpp-dev
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/kubecon18-chained_nf_test/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF_openstack/base_image/vedge_vm_build.sh
@@ -2,10 +2,10 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get install --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
-sudo apt-get -y install linux-headers-$(uname -r)
+sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)
 
 # Install VPP
 VPP_VERSION="18.10-release"
@@ -17,7 +17,7 @@ else
     artifacts+=(${vpp[@]/%/=${VPP_VERSION-}})
 fi
 curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
-apt-get install -y "${artifacts[@]}"
+apt-get --no-install-recommends install -y "${artifacts[@]}"
 sleep 1
 
 sudo sed -i 's/^.*\(net.ipv4.ip_forward\).*/\1=1/g' /etc/sysctl.conf

--- a/comparison/kubecon18-chained_nf_test/VNF_openstack/base_image/vedge_vm_build.sh
+++ b/comparison/kubecon18-chained_nf_test/VNF_openstack/base_image/vedge_vm_build.sh
@@ -2,7 +2,7 @@
 set -o xtrace  # print commands during script execution
 
 sudo apt-get update -y
-sudo apt-get --no-install-recommends install -y --allow-unauthenticated -y make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
+sudo apt-get --no-install-recommends install -y --allow-unauthenticated make gcc libcurl4-openssl-dev python-pip bridge-utils apt-transport-https ca-certificates
 pip install jsonschema
 
 sudo apt-get --no-install-recommends install -y linux-headers-$(uname -r)

--- a/comparison/kubecon18-chained_nf_test/packet_generator/README.md
+++ b/comparison/kubecon18-chained_nf_test/packet_generator/README.md
@@ -93,7 +93,7 @@ Run `source ~/.bashrc` to apply the alias.
 Find the PCI devices that will be used for traffic
 ```
 lspci | grep Eth
-  - Run 'apt install pciutils' if lspci is not installed
+  - Run 'apt-get --no-install-recommends install -y pciutils' if lspci is not installed
   5e:00.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.1 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
   5e:00.4 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx Virtual Function] (*)

--- a/docs/Deploy_K8s_CNF_Testbed.md
+++ b/docs/Deploy_K8s_CNF_Testbed.md
@@ -17,7 +17,7 @@ Once the project on Packet has been configured, start by creating a server (x1.s
 Once the machine is running, start by installing the initial dependencies:
 ```
 $ apt update
-$ apt install -y git \
+$ apt-get --no-install-recommends install -y git \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -31,7 +31,7 @@ $ add-apt-repository \
    $(lsb_release -cs) \
    stable"
 $ apt update
-$ apt install -y docker-ce docker-ce-cli containerd.io
+$ apt-get --no-install-recommends install -y docker-ce docker-ce-cli containerd.io
 
 ## Install Kubectl (from https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl

--- a/examples/network_functions/go-gtp-ubuntu/enb/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/enb/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/enb/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/enb/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y software-properties-common \
-    --no-install-recommends
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/mme/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/mme/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y software-properties-common \
-    --no-install-recommends
+FROM ubuntu:18.04 
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/mme/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/mme/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04 
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/pgw/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/pgw/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y software-properties-common \
-    --no-install-recommends
+FROM ubuntu:18.04 
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/pgw/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/pgw/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04 
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/go-gtp-ubuntu/sgw/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/sgw/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04 
-RUN apt-get update && apt-get --no-install-recommends install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
     software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
 RUN apt-get update && apt-get --no-install-recommends install -y \

--- a/examples/network_functions/go-gtp-ubuntu/sgw/Dockerfile
+++ b/examples/network_functions/go-gtp-ubuntu/sgw/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y software-properties-common \
-    --no-install-recommends
+FROM ubuntu:18.04 
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    software-properties-common
 RUN add-apt-repository ppa:longsleep/golang-backports
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     git \
     golang-1.14 \
     iproute2

--- a/examples/network_functions/rdma_vppcontainer/README.md
+++ b/examples/network_functions/rdma_vppcontainer/README.md
@@ -15,7 +15,7 @@ Before the image can be built, Docker needs to be installed on the host. The ste
 ```
 apt-get update
 
-apt-get install \
+apt-get --no-install-recommends install -y \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -31,7 +31,7 @@ add-apt-repository \
 
 apt-get update
 
-apt-get install docker-ce docker-ce-cli containerd.io
+apt-get --no-install-recommends install -y docker-ce docker-ce-cli containerd.io
 ```
 
 ### Building the base-image

--- a/examples/network_functions/vppcontainer/Dockerfile
+++ b/examples/network_functions/vppcontainer/Dockerfile
@@ -2,14 +2,15 @@ FROM ubuntu:18.04
 
 ENV VPP_VER "20.01"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     gnupg \
     apt-transport-https \
     curl \
     ca-certificates
 
 RUN curl -s https://packagecloud.io/install/repositories/fdio/release/script.deb.sh | bash
-RUN apt-get install -y --no-install-recommends \
+
+RUN apt-get --no-install-recommends install -y \
     dpdk \
     vpp=${VPP_VER}-release \
     vpp-plugin-core=${VPP_VER}-release \

--- a/examples/network_functions/vppcontainer/README.md
+++ b/examples/network_functions/vppcontainer/README.md
@@ -14,7 +14,7 @@ Before the image can be built, Docker needs to be installed on the host. The ste
 ```
 apt-get update
 
-apt-get install \
+apt-get --no-install-recommends install -y \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -30,7 +30,7 @@ add-apt-repository \
 
 apt-get update
 
-apt-get install docker-ce docker-ce-cli containerd.io
+apt-get --no-install-recommends install -y docker-ce docker-ce-cli containerd.io
 ```
 
 ### Building the base-image

--- a/examples/use_case/external-packet-filtering-on-k8s-nsm-on-packet/README.md
+++ b/examples/use_case/external-packet-filtering-on-k8s-nsm-on-packet/README.md
@@ -57,7 +57,7 @@ On the worker node, ensure that the kernel/GRUB is configured correctly. Check b
   - You can use the provided `dpdk-devbind.py` script
   - (Check current driver) `./dpdk-devbind.py -s`
   - (Bind to vfio-pci if needed) `./dpdk-devbind -b vfio-pci 0000:19:00.1 0000:19:00.2`
-  - If `vfio-pci` is not avaialble, install the `dpdk` package on the node (`apt-get install dpdk`)
+  - If `vfio-pci` is not avaialble, install the `dpdk` package on the node (`apt-get --no-install-recommends install -y dpdk`)
 
 At this point you should be ready to install the Packet-filtering example. This has only been tested on a Kubernetes worker where a host vSwitch was already installed - If this is not the case in your deployment there might be additional steps needed to configure the ports with the `vfio-pci` driver, and to configure the ports to use the same VLANs as the "Physical Server" mentioned above.
 

--- a/examples/use_case/gogtp-docker/README.md
+++ b/examples/use_case/gogtp-docker/README.md
@@ -22,14 +22,14 @@ To test connctivity, the following steps can be used from two separeate terminal
 ## Terminal 1
 $ docker exec -it sgi-server /bin/bash
   $ apt-get update
-  $ apt-get -y install python3 iproute2
+  $ apt-get --no-install-recommends install -y python3 iproute2
   $ ip r add 10.0.0.201 via 10.0.1.254 dev eth1
   $ python3 -m http.server 80
 
 ## Terminal 2
 $ docker exec -it ue-ext /bin/bash
   $ apt-get update
-  $ apt-get -y install iputils-ping wget iproute2
+  $ apt-get --no-install-recommends install -y iputils-ping wget iproute2
   $ ip r add 10.0.1.201 via 10.0.0.254 dev eth1
   $ wget http://10.0.1.201
   # You should see wget fetching index.html from the remote web server

--- a/examples/use_case/gogtp-k8s/k8s_bridged_cmk/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_bridged_cmk/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get --no-install-recommends install -y iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y apt-utils ca-certificates iputils-ping wget iproute2
     ip addr add {{ $.Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ $.Values.endpoints.ext.local_addresses.sgi_ip }} via {{ $.Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null

--- a/examples/use_case/gogtp-k8s/k8s_bridged_cmk/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_bridged_cmk/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y iputils-ping wget iproute2
     ip addr add {{ $.Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ $.Values.endpoints.ext.local_addresses.sgi_ip }} via {{ $.Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null
@@ -116,7 +116,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install python3 iproute2
+    apt-get --no-install-recommends install -y python3 iproute2
     ip addr add {{ $.Values.endpoints.ext.local_addresses.sgi_ip }}/24 dev net1
     ip route add {{ $.Values.endpoints.ue.local_addresses.euu_ip }} via {{ $.Values.apps.pgw.local_addresses.sgi_ip }} dev net1
     /opt/bin/cmk isolate --conf-dir=/etc/cmk --socket-id={{ $.Values.apps.pgw.cpu.socket }} --pool=exclusive python3 -- -m http.server 80 --bind {{ $.Values.endpoints.ext.local_addresses.sgi_ip }}

--- a/examples/use_case/gogtp-k8s/k8s_bridged_networks/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_bridged_networks/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y iputils-ping wget iproute2
     ip addr add {{ .Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ext.local_addresses.sgi_ip }} via {{ .Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null
@@ -116,7 +116,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install python3 iproute2
+    apt-get --no-install-recommends install -y python3 iproute2
     ip addr add {{ .Values.endpoints.ext.local_addresses.sgi_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ue.local_addresses.euu_ip }} via {{ .Values.apps.pgw.local_addresses.sgi_ip }} dev net1
     python3 -m http.server 80 --bind {{ .Values.endpoints.ext.local_addresses.sgi_ip }}

--- a/examples/use_case/gogtp-k8s/k8s_bridged_networks/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_bridged_networks/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get --no-install-recommends install -y iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y apt-utils ca-certificates iputils-ping wget iproute2
     ip addr add {{ .Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ext.local_addresses.sgi_ip }} via {{ .Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null

--- a/examples/use_case/gogtp-k8s/k8s_multi_node/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_multi_node/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y iputils-ping wget iproute2
     ip addr add {{ .Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ext.local_addresses.sgi_ip }} via {{ .Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null
@@ -116,7 +116,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get -y install python3 iproute2
+    apt-get --no-install-recommends install -y python3 iproute2
     ip addr add {{ .Values.endpoints.ext.local_addresses.sgi_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ue.local_addresses.euu_ip }} via {{ .Values.apps.pgw.local_addresses.sgi_ip }} dev net1
     python3 -m http.server 80 --bind {{ .Values.endpoints.ext.local_addresses.sgi_ip }}

--- a/examples/use_case/gogtp-k8s/k8s_multi_node/gogtp/templates/configmap.yaml
+++ b/examples/use_case/gogtp-k8s/k8s_multi_node/gogtp/templates/configmap.yaml
@@ -102,7 +102,7 @@ data:
   setup.sh: |-
     #! /bin/bash
     apt-get update
-    apt-get --no-install-recommends install -y iputils-ping wget iproute2
+    apt-get --no-install-recommends install -y apt-utils ca-certificates iputils-ping wget iproute2
     ip addr add {{ .Values.endpoints.ue.local_addresses.euu_ip }}/24 dev net1
     ip route add {{ .Values.endpoints.ext.local_addresses.sgi_ip }} via {{ .Values.apps.enb.local_addresses.euu_ip }} dev net1
     tail -f /dev/null

--- a/examples/use_case/gw-routers-on-k8s-nsm-on-packet/README.md
+++ b/examples/use_case/gw-routers-on-k8s-nsm-on-packet/README.md
@@ -72,7 +72,7 @@ $ (example) echo "-eno3" > /sys/class/net/bond0/bonding/slaves
 
 A good way to check how the ports are mapped is to use `lshw` as follows:
 ```
-$ apt-get install lshw
+$ apt-get --no-install-recommends install -y lshw
 $ lshw -c network -businfo
 Bus info          Device     Class          Description
 =======================================================

--- a/examples/use_case/nsmcon-ext-pf/README.md
+++ b/examples/use_case/nsmcon-ext-pf/README.md
@@ -99,7 +99,7 @@ $ (example) echo "-eno3" > /sys/class/net/bond0/bonding/slaves
 
 A good way to check how the ports are mapped is to use lshw as follows:
 ```
-$ apt-get install lshw
+$ apt-get --no-install-recommends install -y lshw
 $ lshw -c network -businfo
 Bus info          Device     Class          Description
 =======================================================

--- a/tools/deploy/Dockerfile
+++ b/tools/deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:buster as golang
 MAINTAINER "Denver Williams <denver@debian.nz>"
 
-RUN apt install -y git make
+RUN apt-get --no-install-recommends install -y git make
 RUN git clone --depth 1 https://github.com/denverwilliams/terraform-provisioner-ansible.git \
     $GOPATH/src/github.com/radekg/terraform-provisioner-ansible/ && \
     cd $GOPATH/src/github.com/radekg/terraform-provisioner-ansible/ && \
@@ -14,10 +14,10 @@ ENV TERRAFORM_ANSIBLE=v2.0.1
 
 #Install Terraform 
 RUN apt update && \
-    apt install -y software-properties-common && \ 
+    apt-get --no-install-recommends install -y software-properties-common && \ 
     apt-add-repository ppa:ansible/ansible -y && \
     apt update && \
-    apt install -y git curl ansible unzip python-netaddr && \
+    apt-get --no-install-recommends install -y git curl ansible unzip python-netaddr && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \ 

--- a/tools/deploy/Dockerfile
+++ b/tools/deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:buster as golang
 MAINTAINER "Denver Williams <denver@debian.nz>"
 
-RUN apt-get --no-install-recommends install -y git make
+RUN apt-get --no-install-recommends install -y apt-utils git make
 RUN git clone --depth 1 https://github.com/denverwilliams/terraform-provisioner-ansible.git \
     $GOPATH/src/github.com/radekg/terraform-provisioner-ansible/ && \
     cd $GOPATH/src/github.com/radekg/terraform-provisioner-ansible/ && \

--- a/tools/packet_api/Dockerfile
+++ b/tools/packet_api/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex \
 		ruby \
 	' \
 	&& apt-get update \
-	&& apt-get --no-install-recommends install -y --no-install-recommends $buildDeps \
+	&& apt-get --no-install-recommends install -y apt-utils ca-certificates $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \

--- a/tools/packet_api/Dockerfile
+++ b/tools/packet_api/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex \
 		ruby \
 	' \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& apt-get --no-install-recommends install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \

--- a/ubuntu-packer/scripts/packages.sh
+++ b/ubuntu-packer/scripts/packages.sh
@@ -16,7 +16,7 @@ nfs-common
 
 if [[ $INSTALL_DEV_PACKAGES  =~ true || $INSTALL_DEV_PACKAGES =~ 1 ||
         $INSTALL_DEV_PACKAGES =~ yes ]]; then
-  apt-get --no-install-recommends install -y $DEV_PACKAGES
+  apt-get --no-install-recommends install -y apt-utils ca-certificates $DEV_PACKAGES
 fi
 
 apt-get --no-install-recommends install -y $ESSENTIAL_PACKAGES

--- a/ubuntu-packer/scripts/packages.sh
+++ b/ubuntu-packer/scripts/packages.sh
@@ -16,7 +16,7 @@ nfs-common
 
 if [[ $INSTALL_DEV_PACKAGES  =~ true || $INSTALL_DEV_PACKAGES =~ 1 ||
         $INSTALL_DEV_PACKAGES =~ yes ]]; then
-  apt-get -y install $DEV_PACKAGES
+  apt-get --no-install-recommends install -y $DEV_PACKAGES
 fi
 
-apt-get -y install $ESSENTIAL_PACKAGES
+apt-get --no-install-recommends install -y $ESSENTIAL_PACKAGES


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>